### PR TITLE
Defrates1/more updates

### DIFF
--- a/ansible/roles/stig/tasks/TOSS_04_010020.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010020.yml
@@ -22,6 +22,7 @@
         command: 'ssh-keygen -y -f {{ item }}'
         responses:
           'Enter Passphrase:': '*.'
+      check_mode: false
       register: passphrase_prompts
       changed_when: false
       failed_when: false

--- a/ansible/roles/stig/tasks/TOSS_04_010180.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010180.yml
@@ -20,7 +20,7 @@
       ansible.builtin.lineinfile:
         path: /etc/chrony/chrony.conf
         create: true
-        regexp: maxpoll 16
+        regexp: server ntp2.usno.navy.mil iburst maxpoll 16
         line: server tick.usno.navy.mil iburst maxpoll 16
         state: present
         mode: '600'

--- a/ansible/roles/stig/tasks/TOSS_04_010180.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010180.yml
@@ -20,7 +20,7 @@
       ansible.builtin.lineinfile:
         path: /etc/chrony/chrony.conf
         create: true
-        regexp: server ntp2.usno.navy.mil iburst maxpoll 16
+        regexp: maxpoll 16
         line: server tick.usno.navy.mil iburst maxpoll 16
         state: present
         mode: '600'

--- a/ansible/roles/stig/tasks/TOSS_04_010230.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010230.yml
@@ -25,7 +25,7 @@
       ansible.builtin.lineinfile:
         path: /etc/sudoers
         regexp: ^[\s]*Defaults\s(.*)\btimestamp_timeout[\s]*=[\s]*[-]?\w+\b(.*)$
-        line: Defaults \1timestamp_timeout={{ var_sudo_timestamp_timeout }}\2
+        line: Defaults \1timestamp_timeout = {{ var_sudo_timestamp_timeout }}\2
         validate: /usr/sbin/visudo -cf %s
         backrefs: true
       register: edit_sudoers_timestamp_timeout_option

--- a/ansible/roles/stig/tasks/TOSS_04_020050.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020050.yml
@@ -22,9 +22,9 @@
         value: "{{ item.value }}"
         mode: '0600'
       loop: # TODO: need to find how SysAdmins want ccertificates mapped
-        - { option: '^matchrule', value: ''}
-        - { option: '^maprule', value: ''}
-        - { option: '^domains', value: ''}
+        - { option: 'matchrule', value: ''}
+        - { option: 'maprule', value: ''}
+        - { option: 'domains', value: ''}
       register: result
   when:
     - toss_04_020050 | bool

--- a/ansible/roles/stig/tasks/TOSS_04_020210.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020210.yml
@@ -22,7 +22,7 @@
       changed_when: false
       failed_when: home_dirs.rc not in [0,1]
       check_mode: false
-    - name: Set the owner of the local interactive user's home directory
+    - name: Set the group of the local interactive user's home directory
       ansible.builtin.file:
         path: '{{ item.split().1 }}'
         group: '{{ item.split().2 }}'

--- a/ansible/roles/stig/tasks/TOSS_04_020210.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020210.yml
@@ -27,7 +27,8 @@
         path: '{{ item.split().1 }}'
         group: '{{ item.split().2 }}'
       loop: '{{ home_dirs.stdout_lines }}'
-      failed_when: false
+      failed_when: false # This was include to ignore home directories that aren't mounted, but are in /etc/passwd
+                         # Functionally the same as "ignore_errors: true", but will mark the missing home dirs as ok instead of failed, which seemed clearer to me since that is expected behavior
   when:
     - not toss_04_020320 | bool
     - toss_04_020210 | bool

--- a/ansible/roles/stig/tasks/TOSS_04_020210.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020210.yml
@@ -15,20 +15,19 @@
 
 - name: TOSS-04-020210 - All TOSS local interactive user home directories must be group-owned by the home directory owner's primary group.
   block:
-    - name: Get the list of home directories not owned by the user's primary group, ignoring any errors from directories that don't exist on this system
+    - name: Get the list of home directories owned by interactive users
       ansible.builtin.shell:
-        cmd: |
-          set -o pipefail
-          awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/)&&("stat -c '%g' " $6 | getline dir_group)&&(dir_group!=$4){print $1,$6,$4}' /etc/passwd 2>/dev/null
+        cmd: "awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/){print $1,$6,$4}' /etc/passwd"
       register: home_dirs
       changed_when: false
       failed_when: home_dirs.rc not in [0,1]
       check_mode: false
-    - name: Change the owner of the local interactive user's home directory
+    - name: Set the owner of the local interactive user's home directory
       ansible.builtin.file:
         path: '{{ item.split().1 }}'
         group: '{{ item.split().2 }}'
       loop: '{{ home_dirs.stdout_lines }}'
+      failed_when: false
   when:
     - not toss_04_020320 | bool
     - toss_04_020210 | bool

--- a/ansible/roles/stig/tasks/TOSS_04_020210.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020210.yml
@@ -17,7 +17,7 @@
   block:
     - name: Get the list of home directories owned by interactive users
       ansible.builtin.shell:
-        cmd: "awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/){print $1,$6,$4}' /etc/passwd"
+        cmd: "awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/)&&($7 !~ /null/){print $1,$6,$4}' /etc/passwd"
       register: home_dirs
       changed_when: false
       failed_when: home_dirs.rc not in [0,1]

--- a/ansible/roles/stig/tasks/TOSS_04_020230.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020230.yml
@@ -27,7 +27,7 @@
       register: home_dirs
       loop: '{{ local_users }}'
       when:
-        - item.value.1 | int >= 1000 and '/nologin' not in item.value.5 and '/false' not in item.value.5
+        - item.value.1 | int >= 1000 and '/nologin' not in item.value.5 and '/false' not in item.value.5 and '/dev/null' not in item.value.5
         # item.value.1 is the UID                      and item.value.5 is the user's login script
     - name: Verify that all interactive users have a home directory. Users without a home directory might not be enabled and can be set as noninteractive (login shell set to /bin/false)
       ansible.builtin.user:

--- a/ansible/roles/stig/tasks/TOSS_04_020230.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020230.yml
@@ -23,11 +23,12 @@
         local_users: '{{ ansible_facts.getent_passwd | dict2items }}'
     - name: Gather the home directories of local, interactive users
       ansible.builtin.stat:
-        path: '{{ item.value.4 }}'
+        path: '{{ item.value.4 }}' # The path to the interactive user's home directory, ex: /g/g0/defrates
       register: home_dirs
       loop: '{{ local_users }}'
       when:
         - item.value.1 | int >= 1000 and '/nologin' not in item.value.5 and '/false' not in item.value.5
+        # item.value.1 is the UID                      and item.value.5 is the user's login script
     - name: Verify that all interactive users have a home directory. Users without a home directory might not be enabled and can be set as noninteractive (login shell set to /bin/false)
       ansible.builtin.user:
         name: '{{ item.item.key }}'

--- a/ansible/roles/stig/tasks/TOSS_04_020230.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020230.yml
@@ -14,23 +14,29 @@
 
 - name: TOSS-04-020230 - All TOSS local interactive users must have a home directory assigned in the /etc/passwd file.
   block:
-    - name: Verify the integrity of the /etc/passwd file
-      ansible.builtin.command: "pwck -r"
-      failed_when: false
-      changed_when: false
-      check_mode: false
-      register: passwd_check
-    - name: Check if the users are local interactive users
-      ansible.builtin.command: "awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/){print $1}' /etc/passwd"
-      changed_when: false
-      check_mode: false
-      register: local_interactive_users
-    - name: Display any local interactive users without home directories
-      ansible.builtin.debug:
-        var: item
-      when: item.split().0 == "user" and item.split().1[1:-2] in local_interactive_users.stdout
-      # Only check output lines that are flagging a user without a directory, and parse out the '' surrounding the username"
-      loop: '{{ passwd_check.stdout_lines }}'
+    - name: Get all /etc/passwd file entries
+      ansible.builtin.getent:
+        database: passwd
+        split: ':'
+    - name: Create local_users variable from the getent output
+      ansible.builtin.set_fact:
+        local_users: '{{ ansible_facts.getent_passwd | dict2items }}'
+    - name: Gather the home directories of local, interactive users
+      ansible.builtin.stat:
+        path: '{{ item.value.4 }}'
+      register: home_dirs
+      loop: '{{ local_users }}'
+      when:
+        - item.value.1 | int >= 1000 and '/nologin' not in item.value.5 and '/false' not in item.value.5
+    - name: Verify that all interactive users have a home directory. Users without a home directory might not be enabled and can be set as noninteractive (login shell set to /bin/false)
+      ansible.builtin.user:
+        name: '{{ item.item.key }}'
+        shell: /bin/false
+      check_mode: true
+      loop: '{{ home_dirs.results }}'
+      when:
+        - "item.stat is defined"
+        - "not item.stat.exists"
   when:
     - toss_04_020230 | bool
   tags:

--- a/ansible/roles/stig/tasks/TOSS_04_020300.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020300.yml
@@ -12,7 +12,7 @@
   block:
     - name: Get all local users from /etc/passwd, ignoring any errors from directories that don't exist on this system
       ansible.builtin.shell:
-        cmd: "find $(awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/){print $6}' /etc/passwd) -xdev -maxdepth 0 -perm /007 2> /dev/null"
+        cmd: "find $(awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/)&&($7 !~ /dev\/null){print $6}' /etc/passwd) -xdev -maxdepth 0 -perm /007 2> /dev/null"
       register: local_users
       changed_when: false
       failed_when: local_users.rc not in [0,1]

--- a/ansible/roles/stig/tasks/TOSS_04_020300.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020300.yml
@@ -12,7 +12,7 @@
   block:
     - name: Get all local users from /etc/passwd, ignoring any errors from directories that don't exist on this system
       ansible.builtin.shell:
-        cmd: "find $(awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/)&&($7 !~ /dev\/null){print $6}' /etc/passwd) -xdev -maxdepth 0 -perm /007 2> /dev/null"
+        cmd: "find $(awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/)&&($7 !~ /null){print $6}' /etc/passwd) -xdev -maxdepth 0 -perm /007 2> /dev/null"
       register: local_users
       changed_when: false
       failed_when: local_users.rc not in [0,1]

--- a/ansible/roles/stig/tasks/TOSS_04_020300.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020300.yml
@@ -12,7 +12,7 @@
   block:
     - name: Get all local users from /etc/passwd, ignoring any errors from directories that don't exist on this system
       ansible.builtin.shell:
-        cmd: "find $(awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/){print $6}' /etc/passwd) -xdev -maxdepth 0 -not -perm 770 2> /dev/null"
+        cmd: "find $(awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/){print $6}' /etc/passwd) -xdev -maxdepth 0 -perm /007 2> /dev/null"
       register: local_users
       changed_when: false
       failed_when: local_users.rc not in [0,1]

--- a/ansible/roles/stig/tasks/TOSS_04_020310.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020310.yml
@@ -13,7 +13,7 @@
         cmd: "find $(awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/)&&($7 !~ /null/){print $6}' /etc/passwd) -xdev -maxdepth 0 -not -user root 2> /dev/null"
       register: home_dirs
       changed_when: false
-      failed_when: local_users.rc not in [0,1]
+      failed_when: home_dirs.rc not in [0,1]
       check_mode: false
     - name: Change the owner of the local interactive user's home directory
       ansible.builtin.file:

--- a/ansible/roles/stig/tasks/TOSS_04_020310.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020310.yml
@@ -10,7 +10,7 @@
   block:
     - name: Get the list of home directories not owned by root, ignoring any errors from directories that don't exist on this system
       ansible.builtin.shell:
-        cmd: "find $(awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/){print $6}' /etc/passwd) -xdev -maxdepth 0 -not -user root 2> /dev/null"
+        cmd: "find $(awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/)&&($7 !~ /null/){print $6}' /etc/passwd) -xdev -maxdepth 0 -not -user root 2> /dev/null"
       register: home_dirs
       changed_when: false
       failed_when: local_users.rc not in [0,1]

--- a/ansible/roles/stig/tasks/TOSS_04_020320.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020320.yml
@@ -12,20 +12,19 @@
 
 - name: TOSS-04-020320 - All TOSS local interactive user home directories must be owned by the user's primary group.
   block:
-    - name: Get the list of home directories not owned by the user's primary group, ignoring any errors from directories that don't exist on this system
+    - name: Get the list of home directories owned by interactive users
       ansible.builtin.shell:
-        cmd: |
-          set -o pipefail
-          awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/)&&("stat -c '%g' " $6 | getline dir_group)&&(dir_group!=$4){print $1,$6,$4}' /etc/passwd 2>/dev/null
+        cmd: "awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/){print $1,$6,$4}' /etc/passwd"
       register: home_dirs
       changed_when: false
       failed_when: home_dirs.rc not in [0,1]
       check_mode: false
-    - name: Change the owner of the local interactive user's home directory
+    - name: Set the owner of the local interactive user's home directory
       ansible.builtin.file:
         path: '{{ item.split().1 }}'
         group: '{{ item.split().2 }}'
       loop: '{{ home_dirs.stdout_lines }}'
+      failed_when: false
   when:
     - toss_04_020320 | bool
   tags:

--- a/ansible/roles/stig/tasks/TOSS_04_020320.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020320.yml
@@ -24,7 +24,8 @@
         path: '{{ item.split().1 }}'
         group: '{{ item.split().2 }}'
       loop: '{{ home_dirs.stdout_lines }}'
-      failed_when: false
+      failed_when: false # This was include to ignore home directories that aren't mounted, but are in /etc/passwd
+                         # Functionally the same as "ignore_errors: true", but will mark the missing home dirs as ok instead of failed, which seemed clearer to me since that is expected behavior
   when:
     - toss_04_020320 | bool
   tags:

--- a/ansible/roles/stig/tasks/TOSS_04_020320.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020320.yml
@@ -14,7 +14,7 @@
   block:
     - name: Get the list of home directories owned by interactive users
       ansible.builtin.shell:
-        cmd: "awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/){print $1,$6,$4}' /etc/passwd"
+        cmd: "awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/)&&($7 !~ /null/){print $1,$6,$4}' /etc/passwd"
       register: home_dirs
       changed_when: false
       failed_when: home_dirs.rc not in [0,1]

--- a/ansible/roles/stig/tasks/TOSS_04_020320.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020320.yml
@@ -19,7 +19,7 @@
       changed_when: false
       failed_when: home_dirs.rc not in [0,1]
       check_mode: false
-    - name: Set the owner of the local interactive user's home directory
+    - name: Set the group of the local interactive user's home directory
       ansible.builtin.file:
         path: '{{ item.split().1 }}'
         group: '{{ item.split().2 }}'

--- a/ansible/roles/stig/tasks/TOSS_04_040010.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040010.yml
@@ -48,6 +48,7 @@
     - name: 'Configure'
       ansible.builtin.lineinfile:
         path: /etc/rsyslog.conf
+        regexp: '{{ item.item.0.selector }} .*\/var\/log\/secure.*$'
         line: '{{ item.item.0.selector }} /var/log/secure'
         insertafter: ^.*\/var\/log\/secure.*$
         create: true

--- a/ansible/roles/stig/tasks/TOSS_04_040630.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040630.yml
@@ -23,6 +23,7 @@
         line: DIR = p+i+n+u+g+acl+selinux+xattrs
         state: present
         mode: '600'
+        create: true
     - name: TOSS-04-040630 - The TOSS file integrity tool must be configured to verify Access Control Lists (ACLs). Check NORMAL.
       ansible.builtin.lineinfile:
         path: /etc/aide/aide.conf
@@ -30,6 +31,7 @@
         line: NORMAL = p+i+n+u+g+s+m+c+acl+selinux+xattrs+sha512
         state: present
         mode: '600'
+        create: true
   when:
     - toss_04_040630 | bool
   tags:

--- a/ansible/roles/stig/tasks/TOSS_04_040640.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040640.yml
@@ -24,6 +24,7 @@
         line: DIR = p+i+n+u+g+acl+selinux+xattrs
         state: present
         mode: '600'
+        create: true
     - name: TOSS-04-040640 - The TOSS file integrity tool must be configured to verify extended attributes. Check NORMAL.
       ansible.builtin.lineinfile:
         path: /etc/aide/aide.conf
@@ -31,6 +32,7 @@
         line: NORMAL = p+i+n+u+g+s+m+c+acl+selinux+xattrs+sha512
         state: present
         mode: '600'
+        create: true
   when:
     - toss_04_040640 | bool
   tags:


### PR DESCRIPTION
- TOSS-04-020230 - set disabled users that do not have home directories to "non-interactive"
- TOSS-04-020300 - update to allow for "home directories must have mode 0770 or less permissive."
- TOSS-04-020320 and 020210 - break up the 'awk' shell command to avoid hitting file descriptor limit on large nodes
- TOSS-04-040630 and 040640 - set option to create missing file in order to fix failing control