### PR TITLE
add/correct STIG ID in task names and minor corrections

### DIFF
--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -4,4 +4,7 @@
 # This can be removed if running ansible 2.10 or higher.
 ansible/roles/stig/tasks/TOSS_04_020060.yml fqcn[action-core]
 ansible/roles/stig/tasks/TOSS_04_020160.yml fqcn[action-core]
+
+# below rules are ignored in order to grep the appropriate configuration asked in TOSS STIG item 030900 since using a ansible task shell module does not allow a pipe command
 ansible/roles/stig/tasks/TOSS_04_030900.yml command-instead-of-shell
+ansible/roles/stig/tasks/TOSS_04_030900.yml risky-shell-pipe

--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -4,3 +4,4 @@
 # This can be removed if running ansible 2.10 or higher.
 ansible/roles/stig/tasks/TOSS_04_020060.yml fqcn[action-core]
 ansible/roles/stig/tasks/TOSS_04_020160.yml fqcn[action-core]
+ansible/roles/stig/tasks/TOSS_04_030900.yml command-instead-of-shell

--- a/ansible/roles/stig/tasks/TOSS_04_010000.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010000.yml
@@ -28,12 +28,12 @@
 
 - name: TOSS-04-010000 - TOSS must display the Standard Mandatory DoD Notice and Consent Banner or equivalent US Government Agency Notice and Consent Banner before granting local or remote access to the system.
   block:
-    - name: Modify the System Login Banner - ensure correct banner
+    - name: TOSS-04-010000 - Modify the System Login Banner - ensure correct banner
       ansible.builtin.copy:
         content: "{{ login_banner_text }}"
         dest: /etc/issue
         mode: '644'
-    - name: Set the GNOME3 Login Warning Banner Text
+    - name: TOSS-04-010000 - Set the GNOME3 Login Warning Banner Text
       community.general.ini_file:
         dest: /etc/dconf/db/gdm.d/00-security-settings
         section: org/gnome/login-screen
@@ -42,7 +42,7 @@
         create: true
         no_extra_spaces: true
         mode: '644'
-    - name: Insert correct banner setting into /etc/ssh/sshd_config
+    - name: TOSS-04-010000 - Insert correct banner setting into /etc/ssh/sshd_config
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config
         create: true

--- a/ansible/roles/stig/tasks/TOSS_04_010020.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010020.yml
@@ -11,13 +11,13 @@
 
 - name: TOSS-04-010020 - TOSS, for PKI-based authentication, must enforce authorized access to the corresponding private key.
   block:
-    - name: Find all private ssh key files
+    - name: TOSS-04-010020 - Find all private ssh key files
       ansible.builtin.command: 'find / -xdev -type f -regex ".*/id_[a-z0-9]*[^\.pub]$"'
       changed_when: false
       check_mode: false
       register: nouser_files
       failed_when: "nouser_files.rc not in [0,1]"
-    - name: Check if the ssh key files have passphrases set
+    - name: TOSS-04-010020 - Check if the ssh key files have passphrases set
       ansible.builtin.expect:
         command: 'ssh-keygen -y -f {{ item }}'
         responses:
@@ -27,7 +27,7 @@
       changed_when: false
       failed_when: false
       loop: '{{ nouser_files.stdout_lines }}'
-    - name: Verify all the ssh keys prompted for a passphrase
+    - name: TOSS-04-010020 - Verify all the ssh keys prompted for a passphrase
       ansible.builtin.assert:
         that:
           "'Enter passphrase' in item.stdout"

--- a/ansible/roles/stig/tasks/TOSS_04_010060.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010060.yml
@@ -9,7 +9,7 @@
 
 - name: TOSS-04-010060 - The TOSS pam_unix.so module must be configured in the password-auth file to use a FIPS 140-2-approved cryptographic hashing algorithm for system authentication.
   block:
-    - name: Check bad algorithms are absent
+    - name: TOSS-04-010060 - Check bad algorithms are absent
       community.general.pamd:
         name: password-auth
         type: password
@@ -22,7 +22,7 @@
           - sha256
         state: args_absent
         backup: true
-    - name: Check good algorithms are present
+    - name: TOSS-04-010060 - Check good algorithms are present
       community.general.pamd:
         name: password-auth
         type: password

--- a/ansible/roles/stig/tasks/TOSS_04_010070.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010070.yml
@@ -9,7 +9,7 @@
 
 - name: TOSS-04-010070 - The TOSS pam_unix.so module must be configured in the system-auth file to use a FIPS 140-2-approved cryptographic hashing algorithm for system authentication.
   block:
-    - name: Check bad algorithms are absent
+    - name: TOSS-04-010070 - Check bad algorithms are absent
       community.general.pamd:
         name: system-auth
         type: password
@@ -22,7 +22,7 @@
           - sha256
         state: args_absent
         backup: true
-    - name: Check good algorithms are present
+    - name: TOSS-04-010070 - Check good algorithms are present
       community.general.pamd:
         name: system-auth
         type: password

--- a/ansible/roles/stig/tasks/TOSS_04_010080.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010080.yml
@@ -10,7 +10,7 @@
 
 - name: TOSS-04-010080 - The TOSS operating system must implement DoD-approved encryption in the OpenSSL package.
   block:
-    - name: Check for duplicate values of TLS.MinProtocol in /etc/crypto-policies/back-ends/opensslcnf.config
+    - name: TOSS-04-010080 - Check for duplicate values of TLS.MinProtocol in /etc/crypto-policies/back-ends/opensslcnf.config
       ansible.builtin.lineinfile:
         path: /etc/crypto-policies/back-ends/opensslcnf.config
         create: false
@@ -19,14 +19,14 @@
       check_mode: true
       changed_when: false
       register: dupes
-    - name: Deduplicate values of TLS.MinProtocol from /etc/crypto-policies/back-ends/opensslcnf.config
+    - name: TOSS-04-010080 - Deduplicate values of TLS.MinProtocol from /etc/crypto-policies/back-ends/opensslcnf.config
       ansible.builtin.lineinfile:
         path: /etc/crypto-policies/back-ends/opensslcnf.config
         create: false
         regexp: (?i)^\s*TLS.MinProtocol\s+
         state: absent
       when: dupes.found is defined and dupes.found > 1
-    - name: Insert correct line of TLS.MinProtocol to /etc/crypto-policies/back-ends/opensslcnf.config
+    - name: TOSS-04-010080 - Insert correct line of TLS.MinProtocol to /etc/crypto-policies/back-ends/opensslcnf.config
       ansible.builtin.lineinfile:
         path: /etc/crypto-policies/back-ends/opensslcnf.config
         create: true
@@ -34,7 +34,7 @@
         line: TLS.MinProtocol = TLSv1.2
         state: present
         mode: '644'
-    - name: Check for duplicate values of DTLS.MinProtocol in /etc/crypto-policies/back-ends/opensslcnf.config
+    - name: TOSS-04-010080 - Check for duplicate values of DTLS.MinProtocol in /etc/crypto-policies/back-ends/opensslcnf.config
       ansible.builtin.lineinfile:
         path: /etc/crypto-policies/back-ends/opensslcnf.config
         create: false
@@ -43,14 +43,14 @@
       check_mode: true
       changed_when: false
       register: dupes
-    - name: Deduplicate values of DTLS.MinProtocol from /etc/crypto-policies/back-ends/opensslcnf.config
+    - name: TOSS-04-010080 - Deduplicate values of DTLS.MinProtocol from /etc/crypto-policies/back-ends/opensslcnf.config
       ansible.builtin.lineinfile:
         path: /etc/crypto-policies/back-ends/opensslcnf.config
         create: false
         regexp: (?i)^\s*DTLS.MinProtocol\s+
         state: absent
       when: dupes.found is defined and dupes.found > 1
-    - name: Insert correct line of DTLS.MinProtocol to /etc/crypto-policies/back-ends/opensslcnf.config
+    - name: TOSS-04-010080 - Insert correct line of DTLS.MinProtocol to /etc/crypto-policies/back-ends/opensslcnf.config
       ansible.builtin.lineinfile:
         path: /etc/crypto-policies/back-ends/opensslcnf.config
         create: true

--- a/ansible/roles/stig/tasks/TOSS_04_010100.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010100.yml
@@ -9,12 +9,12 @@
 
 - name: TOSS-04-010100 - TOSS must prevent unauthorized and unintended information transfer via shared system resources.
   block:
-    - name: Check to see if there are any public directories without an owner
+    - name: TOSS-04-010100 - Check to see if there are any public directories without an owner
       ansible.builtin.command: find / -xdev -nouser -type d -perm -0002
       register: unowned_dirs
       check_mode: false
       changed_when: false
-    - name: Set the owner of public directories without an owner to root
+    - name: TOSS-04-010100 - Set the owner of public directories without an owner to root
       ansible.builtin.file:
         path: "{{ item }}"
         owner: root

--- a/ansible/roles/stig/tasks/TOSS_04_010120.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010120.yml
@@ -35,7 +35,7 @@
 
 - name: TOSS-04-010120 - TOSS must display the Standard Mandatory DoD Notice and Consent Banner or equivalent US Government Agency Notice and Consent Banner before granting local or remote access to the system via a ssh logon.
   block:
-    - name: Check `Banner` in sshd_config
+    - name: TOSS-04-010120 - Check `Banner` in sshd_config
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config
         regexp: '^(?i)#?Banner'

--- a/ansible/roles/stig/tasks/TOSS_04_010140.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010140.yml
@@ -21,37 +21,37 @@
 
 - name: TOSS-04-010140 - The TOSS operating system must implement DoD-approved encryption to protect the confidentiality of SSH connections.
   block:
-    - name: Verify that system-wide crypto policies are in effect and CRYPTO_POLICY is not defined in sshd
+    - name: TOSS-04-010140 - Verify that system-wide crypto policies are in effect and CRYPTO_POLICY is not defined in sshd
       ansible.builtin.lineinfile:
         path: /etc/sysconfig/sshd
         regexp: '^CRYPTO_POLICY='
         state: absent
       changed_when: false
       register: out
-    - name: Comment out CRYPTO_POLICY if it is defined in sshd
+    - name: TOSS-04-010140 - Comment out CRYPTO_POLICY if it is defined in sshd
       ansible.builtin.replace:
         path: /etc/sysconfig/sshd
         regexp: '^CRYPTO_POLICY='
         replace: '#CRYPTO_POLICY='
       when: out.found
-    - name: Check which system-wide crypto policy is in use
+    - name: TOSS-04-010140 - Check which system-wide crypto policy is in use
       ansible.builtin.command: update-crypto-policies --show
       register: crypto_policy_output
       changed_when: false
       check_mode: false
-    - name: Configure the TOSS SSH daemon to use only ciphers employing FIPS 140-2-approved algorithms
+    - name: TOSS-04-010140 - Configure the TOSS SSH daemon to use only ciphers employing FIPS 140-2-approved algorithms
       ansible.builtin.command: fips-mode-setup --enable
       # Note: Running this command will create a symlink from opensshserver.config and openssh.config to other files,  making permission look like '0777' to ansible's checks
       changed_when: fips_setup_output.rc is defined
       register: fips_setup_output
       when: "'FIPS' not in crypto_policy_output.stdout"
-    - name: 'Set crypto policy in opensshserver.config'
+    - name: 'TOSS-04-010140 - Set crypto policy in opensshserver.config'
       ansible.builtin.replace:
         path: /etc/crypto-policies/back-ends/opensshserver.config
         regexp: '^#?CRYPTO_POLICY=\S+'
         replace: "CRYPTO_POLICY='-oCiphers={{ sshd_approved_ciphers }}"
         mode: '0644'
-    - name: 'Set crypto policy in openssh.config'
+    - name: 'TOSS-04-010140 - Set crypto policy in openssh.config'
       ansible.builtin.replace:
         path: /etc/crypto-policies/back-ends/openssh.config
         regexp: '^#?Ciphers.*$'

--- a/ansible/roles/stig/tasks/TOSS_04_010160.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010160.yml
@@ -16,12 +16,12 @@
 
 - name: TOSS-04-010160 - The TOSS SSH daemon must be configured to use only Message Authentication Codes (MACs) employing FIPS 140-2 validated cryptographic hash algorithms.
   block:
-    - name: 'Set MAC in opensshserver.config'
+    - name: 'TOSS-04-010160 - Set MAC in opensshserver.config'
       ansible.builtin.replace:
         path: /etc/crypto-policies/back-ends/opensshserver.config
         regexp: '-oMACs=\S+'
         replace: '-oMACs=hmac-sha2-512,hmac-sha2-256'
-    - name: 'Set MAC in openssh.config'
+    - name: 'TOSS-04-010160 - Set MAC in openssh.config'
       ansible.builtin.lineinfile:
         path: /etc/crypto-policies/back-ends/openssh.config
         regexp: 'MACs \S+'

--- a/ansible/roles/stig/tasks/TOSS_04_010180.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010180.yml
@@ -24,8 +24,6 @@
         line: server tick.usno.navy.mil iburst maxpoll 16
         state: present
         mode: '600'
-        firstmatch: true
-        backrefs: true
     - name: TOSS-04-010180 - Check time source - tick.usno.navy.mil
       ansible.builtin.lineinfile:
         path: /etc/chrony.conf

--- a/ansible/roles/stig/tasks/TOSS_04_010220.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010220.yml
@@ -17,14 +17,14 @@
 
 - name: TOSS-04-010220 - TOSS must prevent the installation of patches, service packs, device drivers, or operating system components without verification they have been digitally signed using a certificate that is recognized and approved by the organization.
   block:
-    - name: Register /etc/yum.repos.d/*.yml files
+    - name: TOSS-04-010220 - Register /etc/yum.repos.d/*.yml files
       ansible.builtin.find:
         paths: /etc/yum.repos.d
         patterns: '*.repo'
         file_type: file
         recurse: false
       register: yum_repo_files
-    - name: Ensure gpgcheck Enabled For All Package Repositories
+    - name: TOSS-04-010220 - Ensure gpgcheck Enabled For All Package Repositories
       ansible.builtin.replace:
         path: '{{ yum_repo_file.path }}'
         regexp: '^#?\s*gpgcheck=[0-9]+'

--- a/ansible/roles/stig/tasks/TOSS_04_010230.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010230.yml
@@ -9,19 +9,19 @@
 
 - name: TOSS-04-010230 - TOSS must require re-authentication when using the "sudo" command.
   block:
-    - name: Find out if /etc/sudoers.d/* files contain 'Defaults timestamp_timeout' to be deduplicated
+    - name: TOSS-04-010230 - Find out if /etc/sudoers.d/* files contain 'Defaults timestamp_timeout' to be deduplicated
       ansible.builtin.find:
         path: /etc/sudoers.d
         patterns: '*'
         contains: ^[\s]*Defaults\s.*\btimestamp_timeout[\s]*=.*
       register: sudoers_d_defaults_timestamp_timeout
-    - name: Remove found occurrences of 'Defaults timestamp_timeout' from /etc/sudoers.d/* files
+    - name: TOSS-04-010230 - Remove found occurrences of 'Defaults timestamp_timeout' from /etc/sudoers.d/* files
       ansible.builtin.lineinfile:
         path: '{{ item.path }}'
         regexp: ^[\s]*Defaults\s.*\btimestamp_timeout[\s]*=.*
         state: absent
       with_items: '{{ sudoers_d_defaults_timestamp_timeout.files }}'
-    - name: Ensure timestamp_timeout is enabled with the appropriate value in /etc/sudoers
+    - name: TOSS-04-010230 - Ensure timestamp_timeout is enabled with the appropriate value in /etc/sudoers
       ansible.builtin.lineinfile:
         path: /etc/sudoers
         regexp: ^[\s]*Defaults\s(.*)\btimestamp_timeout[\s]*=[\s]*[-]?\w+\b(.*)$
@@ -29,7 +29,7 @@
         validate: /usr/sbin/visudo -cf %s
         backrefs: true
       register: edit_sudoers_timestamp_timeout_option
-    - name: Enable timestamp_timeout option with appropriate value in /etc/sudoers
+    - name: TOSS-04-010230 - Enable timestamp_timeout option with appropriate value in /etc/sudoers
       ansible.builtin.lineinfile:
         path: /etc/sudoers
         line: Defaults timestamp_timeout={{ var_sudo_timestamp_timeout }}

--- a/ansible/roles/stig/tasks/TOSS_04_010250.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010250.yml
@@ -15,13 +15,13 @@
 
 - name: TOSS-04-010250 - TOSS must prohibit the use of cached authentications after one day.
   block:
-    - name: Check that SSSD allows cached authentications
+    - name: TOSS-04-010250 - Check that SSSD allows cached authentications
       ansible.builtin.lineinfile:
         path: /etc/sssd/sssd.conf
         regexp: '^cache_credentials = true'
         state: absent
       register: cache_cred_enabled
-    - name: Check that SSSD prohibits the use of cached authentications after one day
+    - name: TOSS-04-010250 - Check that SSSD prohibits the use of cached authentications after one day
       community.general.ini_file:
         dest: /etc/sssd/sssd.conf
         section: pam

--- a/ansible/roles/stig/tasks/TOSS_04_010280.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010280.yml
@@ -10,11 +10,11 @@
 
 - name: TOSS-04-010280 - All TOSS networked systems must have and implement SSH to protect the confidentiality and integrity of transmitted and received information, as well as information during preparation for transmission.
   block:
-    - name: Ensure openssh-server is installed
+    - name: TOSS-04-010280 - Ensure openssh-server is installed
       ansible.builtin.package:
         name: openssh-server
         state: present
-    - name: Enable service sshd
+    - name: TOSS-04-010280 - Enable service sshd
       ansible.builtin.service:
         name: sshd
         enabled: true

--- a/ansible/roles/stig/tasks/TOSS_04_010330.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010330.yml
@@ -17,32 +17,32 @@
 
 - name: TOSS-04-010330 - For TOSS systems using Domain Name Servers (DNS) resolution, at least two name servers must be configured.
   block:
-    - name: Determine whether the system is using local or DNS name resolution
+    - name: TOSS-04-010330 - Determine whether the system is using local or DNS name resolution
       ansible.builtin.command: "grep hosts /etc/nsswitch.conf"
       changed_when: false
       check_mode: false
       failed_when: dns_entry.rc not in [0,1]
       register: dns_entry
-    - name: Get the size "/etc/resolv.conf"
+    - name: TOSS-04-010330 - Get the size "/etc/resolv.conf"
       ansible.builtin.stat:
         path: /etc/resolv.conf
       register: resolv_stat
       when: dns_entry.rc != 0
-    - name: Verify that "/etc/resolv.conf" is empty
+    - name: TOSS-04-010330 - Verify that "/etc/resolv.conf" is empty
       ansible.builtin.assert:
         that:
           - resolv_stat.stat.size == 0
         fail_msg: "If local host authentication is being used, the /etc/resolv.conf file must be emtpy"
         quiet: true
       when: dns_entry.rc != 0
-    - name: Verify the operating system is configured to use two or more name servers for DNS resolution
+    - name: TOSS-04-010330 - Verify the operating system is configured to use two or more name servers for DNS resolution
       ansible.builtin.command: "grep '^nameserver' /etc/resolv.conf"
       register: num_name_servers
       changed_when: false
       check_mode: false
       failed_when: dns_entry.rc not in [0,1]
       when: dns_entry.rc == 0
-    - name: Check that there are at least two name servers for DNS resolution
+    - name: TOSS-04-010330 - Check that there are at least two name servers for DNS resolution
       ansible.builtin.assert:
         that:
           - num_name_servers.stdout is defined

--- a/ansible/roles/stig/tasks/TOSS_04_010350.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010350.yml
@@ -7,14 +7,14 @@
 
 - name: TOSS-04-010350 - The root account must be the only account having unrestricted access to the TOSS system.
   block:
-    - name: Verify Only Root Has UID 0
+    - name: TOSS-04-010350 - Verify Only Root Has UID 0
       ansible.builtin.command: awk -F':' '$3 == 0 && $1 != "root" { print $1 }' /etc/passwd
       register: uidzero
       changed_when: false
       failed_when: false
       check_mode: false
 
-    - name: Verify Only Root Has UID 0
+    - name: TOSS-04-010350 - Verify Only Root Has UID 0
       ansible.builtin.assert:
         that:
           - uidzero.stdout_lines | length == 0

--- a/ansible/roles/stig/tasks/TOSS_04_010370.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010370.yml
@@ -8,7 +8,7 @@
 - name: TOSS-04-010370 - There must be no ".shosts" files on The TOSS operating system.
   block:
     # $ sudo find / -name '*.shosts'
-    - name: Register *.shosts files
+    - name: TOSS-04-010370 - Register *.shosts files
       ansible.builtin.find:
         # TODO: Add -xdev flag to avoid crossing filesystems
         paths: /
@@ -17,7 +17,7 @@
         recurse: false
       register: shost_files
 
-    - name: Verify there are no .shosts files on the host
+    - name: TOSS-04-010370 - Verify there are no .shosts files on the host
       ansible.builtin.assert:
         that:
           - shost_files.matched == 0

--- a/ansible/roles/stig/tasks/TOSS_04_010390.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010390.yml
@@ -13,7 +13,7 @@
 
 - name: TOSS-04-010390 - TOSS must not be performing packet forwarding unless the system is a router.
   block:
-    - name: Ensure ipv4 forwarding is disabled
+    - name: TOSS-04-010390 - Ensure ipv4 forwarding is disabled
       ansible.builtin.lineinfile:
         path: /etc/sysctl.conf
         regexp: '^(?i)#?net.ipv4.ip_forward'
@@ -21,7 +21,7 @@
         state: present
         backup: true
       notify: Reload sysctl
-    - name: Ensure ipv6 forwarding is disabled
+    - name: TOSS-04-010390 - Ensure ipv6 forwarding is disabled
       ansible.builtin.lineinfile:
         path: /etc/sysctl.conf
         regexp: '^(?i)#?net.ipv6.conf.all.forwarding'

--- a/ansible/roles/stig/tasks/TOSS_04_020000.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020000.yml
@@ -14,13 +14,13 @@
 
 - name: TOSS-04-020000 - TOSS must enforce the limit of three consecutive invalid logon attempts by a user during a 15-minute time period.
   block:
-    - name: Ensure a maximum number of invalid login attempts
+    - name: TOSS-04-020000 - Ensure a maximum number of invalid login attempts
       ansible.builtin.lineinfile:
         path: /etc/security/faillock.conf
         regexp: ^\s*deny\s*=
         line: deny = {{ pam_faillock_deny }}
         state: present
-    - name: Ensure the auth fail time range is set correctly.
+    - name: TOSS-04-020000 - Ensure the auth fail time range is set correctly.
       ansible.builtin.lineinfile:
         path: /etc/security/faillock.conf
         regexp: ^\s*fail_interval\s*=

--- a/ansible/roles/stig/tasks/TOSS_04_020020.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020020.yml
@@ -11,7 +11,7 @@
 
 - name: TOSS-04-020020 - TOSS must retain a user's session lock until that user reestablishes access using established identification and authentication procedures.
   block:
-    - name: Enable GNOME3 Screensaver Lock After Idle Period
+    - name: TOSS-04-020020 - Enable GNOME3 Screensaver Lock After Idle Period
       community.general.ini_file:
         dest: /etc/dconf/db/local.d/00-screensaver
         section: org/gnome/desktop/screensaver
@@ -20,11 +20,11 @@
         create: true
         no_extra_spaces: true
         mode: '0644'
-    - name: Update GNOME3 screenserver lock-screen-enabled false
+    - name: TOSS-04-020020 - Update GNOME3 screenserver lock-screen-enabled false
       ansible.builtin.command: gsettings get org.gnome.desktop.screensaver lock-enabled
       register: lock_screen_output
       changed_when: false
-    - name: Dconf Update
+    - name: TOSS-04-020020 - Dconf Update
       ansible.builtin.command: dconf update
       register: update_output
       changed_when: false # TODO: figure out what the output should be when sucessful

--- a/ansible/roles/stig/tasks/TOSS_04_020030.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020030.yml
@@ -11,7 +11,7 @@
 
 - name: TOSS-04-020030 - TOSS must automatically lock graphical user sessions after 15 minutes of inactivity.
   block:
-    - name: Set GNOME3 Screensaver Inactivity Timeout
+    - name: TOSS-04-020030 - Set GNOME3 Screensaver Inactivity Timeout
       community.general.ini_file:
         dest: /etc/dconf/db/local.d/00-screensaver
         section: org/gnome/desktop/session
@@ -20,7 +20,7 @@
         create: true
         no_extra_spaces: true
         mode: '0644'
-    - name: Dconf Update
+    - name: TOSS-04-020030 - Dconf Update
       ansible.builtin.command: dconf update
       register: update_output
       changed_when: false # TODO: figure out what the output should be when sucessful

--- a/ansible/roles/stig/tasks/TOSS_04_020050.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020050.yml
@@ -14,7 +14,7 @@
 
 - name: TOSS-04-020050 - TOSS must map the authenticated identity to the user or group account for PKI-based authentication.
   block:
-    - name: Verify the certificate of the user or group is mapped to the corresponding user or group in the "sssd.conf" file
+    - name: TOSS-04-020050 - Verify the certificate of the user or group is mapped to the corresponding user or group in the "sssd.conf" file
       community.general.ini_file:
         path: /etc/sssd/sssd.conf
         section: "certmap"

--- a/ansible/roles/stig/tasks/TOSS_04_020060.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020060.yml
@@ -9,18 +9,18 @@
 
 - name: TOSS-04-020060 - TOSS duplicate User IDs (UIDs) must not exist for interactive users.
   block:
-    - name: Verify no users have the same UUID
+    - name: TOSS-04-020060 - Verify no users have the same UUID
       command: "awk -F ':' 'list[$3]++{print $1,$3}' /etc/passwd"
       failed_when: all_dupe_uuid.rc not in [0,1]
       changed_when: false
       check_mode: false
       register: all_dupe_uuid
-    - name: Display user(s) that have a duplicated UID
+    - name: TOSS-04-020060 - Display user(s) that have a duplicated UID
       ansible.builtin.debug:
         var: all_dupe_uuid.stdout_lines
         verbosity: 1
       when: all_dupe_uuid.stdout_lines | length > 0
-    - name: Fail if there are duplicates
+    - name: TOSS-04-020060 - Fail if there are duplicates
       ansible.builtin.assert:
         that:
           - all_dupe_uuid.stdout_lines | length == 0

--- a/ansible/roles/stig/tasks/TOSS_04_020070.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020070.yml
@@ -21,13 +21,13 @@
 
 - name: TOSS-04-020070 - TOSS must use multifactor authentication for network and local access to privileged and non-privileged accounts.
   block:
-    - name: Test for domain group
+    - name: TOSS-04-020070 - Test for domain group
       ansible.builtin.command: grep '^\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
       register: test_grep_domain
       ignore_errors: true
       changed_when: false
       check_mode: false
-    - name: Add default domain group (if no domain there)
+    - name: TOSS-04-020070 - Add default domain group (if no domain there)
       community.general.ini_file:
         path: /etc/sssd/sssd.conf
         section: '{{ item.section }}'
@@ -45,7 +45,7 @@
       when:
         - test_grep_domain.stdout is defined
         - test_grep_domain.stdout | length < 1
-    - name: Verify the pam section
+    - name: TOSS-04-020070 - Verify the pam section
       community.general.ini_file:
         dest: /etc/sssd/sssd.conf
         section: pam
@@ -54,13 +54,13 @@
         create: true
         mode: 384
 
-    - name: Enable Smartcards in SSSD - Check integrity of authselect current profile
+    - name: TOSS-04-020070 - Enable Smartcards in SSSD - Check integrity of authselect current profile
       ansible.builtin.command: "authselect check"
       register: result_authselect_check_cmd
       changed_when: false
       check_mode: false
       failed_when: false
-    - name: Enable Smartcards in SSSD - Informative message based on the authselect integrity check result
+    - name: TOSS-04-020070 - Enable Smartcards in SSSD - Informative message based on the authselect integrity check result
       ansible.builtin.assert:
         that:
           - result_authselect_check_cmd.rc == 0
@@ -72,7 +72,7 @@
           - In cases where the default authselect profile does not cover a specific demand, a custom authselect profile is recommended.
         success_msg:
           - authselect integrity check passed
-    - name: Enable Smartcards in SSSD - Get authselect current features
+    - name: TOSS-04-020070 - Enable Smartcards in SSSD - Get authselect current features
       ansible.builtin.shell:
         cmd: set -o pipefail && authselect current | tail -n+3 | awk '{ print $2 }'
       register: result_authselect_features
@@ -80,7 +80,7 @@
       check_mode: false
       when:
         - result_authselect_check_cmd is success
-    - name: Enable Smartcards in SSSD - Ensure "with-smartcard" feature is enabled using authselect tool
+    - name: TOSS-04-020070 - Enable Smartcards in SSSD - Ensure "with-smartcard" feature is enabled using authselect tool
       ansible.builtin.command:
         cmd: authselect enable-feature with-smartcard
       register: result_authselect_enable_feature_cmd
@@ -88,7 +88,7 @@
       when:
         - result_authselect_check_cmd is success
         - result_authselect_features.stdout is not search("with-smartcard")
-    - name: Enable Smartcards in SSSD - Ensure authselect changes are applied
+    - name: TOSS-04-020070 - Enable Smartcards in SSSD - Ensure authselect changes are applied
       ansible.builtin.command:
         cmd: authselect apply-changes -b
       changed_when: false

--- a/ansible/roles/stig/tasks/TOSS_04_020140.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020140.yml
@@ -11,20 +11,20 @@
 
 - name: TOSS-04-020140 - TOSS must automatically remove or disable emergency accounts after the crisis is resolved or 72 hours.
   block:
-    - name: Get all /etc/passwd file entries
+    - name: TOSS-04-020140 - Get all /etc/passwd file entries
       ansible.builtin.getent:
         database: passwd
         split: ':'
-    - name: Create local_users variable from the getent output
+    - name: TOSS-04-020140 - Create local_users variable from the getent output
       ansible.builtin.set_fact:
         local_users: '{{ ansible_facts.getent_passwd | dict2items }}'
-    - name: Get the password expiry information
+    - name: TOSS-04-020140 - Get the password expiry information
       ansible.builtin.command: "chage -l {{ item.key }}"
       check_mode: false
       changed_when: false
       register: password_expiry
       loop: "{{ local_users }}"
-    - name: List all accounts password expiry information. If one is a emergency account, configure the system to terminate the account after 72 hours
+    - name: TOSS-04-020140 - List all accounts password expiry information. If one is a emergency account, configure the system to terminate the account after 72 hours
       ansible.builtin.debug:
         var: password_expiry
         verbosity: 1

--- a/ansible/roles/stig/tasks/TOSS_04_020160.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020160.yml
@@ -12,12 +12,12 @@
 
 - name: TOSS-04-020160 - TOSS must protect wireless access to the system using authentication of users and/or devices.
   block:
-    - name: Get all network devices
+    - name: TOSS-04-020160 - Get all network devices
       ansible.builtin.command: "nmcli device status"
       changed_when: false
       check_mode: false
       register: wifi_devices
-    - name: Disable all wireless network interfaces
+    - name: TOSS-04-020160 - Disable all wireless network interfaces
       command: "nmcli radio all off"
       changed_when: false
       when: "'wifi' in wifi_devices.stdout"

--- a/ansible/roles/stig/tasks/TOSS_04_020180.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020180.yml
@@ -9,11 +9,11 @@
 
 - name: TOSS-04-020180 - TOSS must require users to reauthenticate for privilege escalation.
   block:
-    - name: Find /etc/sudoers.d/ files
+    - name: TOSS-04-020180 - Find /etc/sudoers.d/ files
       ansible.builtin.find:
         paths: /etc/sudoers.d/
       register: sudoers
-    - name: Remove lines containing !authenticate from sudoers files
+    - name: TOSS-04-020180 - Remove lines containing !authenticate from sudoers files
       ansible.builtin.replace:
         regexp: (^(?!#).*[\s]+\!authenticate.*$)
         replace: '# \g<1>'

--- a/ansible/roles/stig/tasks/TOSS_04_020190.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020190.yml
@@ -10,12 +10,12 @@
 
 - name: TOSS-04-020190 - TOSS must require users to provide a password for privilege escalation.
   block:
-    - name: Find /etc/sudoers.d/ files
+    - name: TOSS-04-020190 - Find /etc/sudoers.d/ files
       ansible.builtin.find:
         paths:
           - /etc/sudoers.d/
       register: sudoers
-    - name: Remove lines containing NOPASSWD from sudoers files
+    - name: TOSS-04-020190 - Remove lines containing NOPASSWD from sudoers files
       ansible.builtin.replace:
         regexp: (^(?!#).*[\s]+NOPASSWD[\s]*\:.*$)
         replace: '# \g<1>'

--- a/ansible/roles/stig/tasks/TOSS_04_020210.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020210.yml
@@ -15,14 +15,14 @@
 
 - name: TOSS-04-020210 - All TOSS local interactive user home directories must be group-owned by the home directory owner's primary group.
   block:
-    - name: Get the list of home directories owned by interactive users
+    - name: TOSS-04-020210 - Get the list of home directories owned by interactive users
       ansible.builtin.shell:
         cmd: "awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/)&&($7 !~ /null/){print $1,$6,$4}' /etc/passwd"
       register: home_dirs
       changed_when: false
       failed_when: home_dirs.rc not in [0,1]
       check_mode: false
-    - name: Set the group of the local interactive user's home directory
+    - name: TOSS-04-020210 - Set the group of the local interactive user's home directory
       ansible.builtin.file:
         path: '{{ item.split().1 }}'
         group: '{{ item.split().2 }}'

--- a/ansible/roles/stig/tasks/TOSS_04_020230.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020230.yml
@@ -14,14 +14,14 @@
 
 - name: TOSS-04-020230 - All TOSS local interactive users must have a home directory assigned in the /etc/passwd file.
   block:
-    - name: Get all /etc/passwd file entries
+    - name: TOSS-04-020230 - Get all /etc/passwd file entries
       ansible.builtin.getent:
         database: passwd
         split: ':'
-    - name: Create local_users variable from the getent output
+    - name: TOSS-04-020230 - Create local_users variable from the getent output
       ansible.builtin.set_fact:
         local_users: '{{ ansible_facts.getent_passwd | dict2items }}'
-    - name: Gather the home directories of local, interactive users
+    - name: TOSS-04-020230 - Gather the home directories of local, interactive users
       ansible.builtin.stat:
         path: '{{ item.value.4 }}' # The path to the interactive user's home directory, ex: /g/g0/defrates
       register: home_dirs
@@ -29,7 +29,7 @@
       when:
         - item.value.1 | int >= 1000 and '/nologin' not in item.value.5 and '/false' not in item.value.5 and '/dev/null' not in item.value.5
         # item.value.1 is the UID                      and item.value.5 is the user's login script
-    - name: Verify that all interactive users have a home directory. Users without a home directory might not be enabled and can be set as noninteractive (login shell set to /bin/false)
+    - name: TOSS-04-020230 - Verify that all interactive users have a home directory. Users without a home directory might not be enabled and can be set as noninteractive (login shell set to /bin/false)
       ansible.builtin.user:
         name: '{{ item.item.key }}'
         shell: /bin/false

--- a/ansible/roles/stig/tasks/TOSS_04_020240.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020240.yml
@@ -11,7 +11,7 @@
 
 - name: TOSS-04-020240 - The x86 Ctrl-Alt-Delete key sequence in TOSS must be disabled if a graphical user interface is installed.
   block:
-    - name: Disable Ctrl-Alt-Del Reboot Key Sequence in GNOME3
+    - name: TOSS-04-020240 - Disable Ctrl-Alt-Del Reboot Key Sequence in GNOME3
       community.general.ini_file:
         dest: /etc/dconf/db/local.d/00-disable-CAD
         section: org/gnome/settings-daemon/plugins/media-keys
@@ -20,7 +20,7 @@
         create: true
         no_extra_spaces: true
         mode: '0644'
-    - name: Dconf Update
+    - name: TOSS-04-020240 - Dconf Update
       ansible.builtin.command: dconf update
       register: update_output
       changed_when: false

--- a/ansible/roles/stig/tasks/TOSS_04_020250.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020250.yml
@@ -10,7 +10,7 @@
 
 - name: TOSS-04-020250 - TOSS must disable the user list at logon for graphical user interfaces.
   block:
-    - name: Disable the GNOME3 Login User List
+    - name: TOSS-04-020250 - Disable the GNOME3 Login User List
       community.general.ini_file:
         dest: /etc/dconf/db/local.d/02-login-screen
         section: org/gnome/login-screen
@@ -19,7 +19,7 @@
         no_extra_spaces: true
         create: true
         mode: '0644'
-    - name: Dconf Update
+    - name: TOSS-04-020250 - Dconf Update
       ansible.builtin.command: dconf update
       register: update_output
       changed_when: false

--- a/ansible/roles/stig/tasks/TOSS_04_020260.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020260.yml
@@ -8,7 +8,7 @@
 
 - name: TOSS-04-020260 - TOSS must display the date and time of the last successful account logon upon an SSH logon.
   block:
-    - name: Check for duplicate values
+    - name: TOSS-04-020260 - Check for duplicate values
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config
         create: false
@@ -17,14 +17,14 @@
       check_mode: true
       changed_when: false
       register: dupes
-    - name: Deduplicate values from /etc/ssh/sshd_config
+    - name: TOSS-04-020260 - Deduplicate values from /etc/ssh/sshd_config
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config
         create: false
         regexp: (?i)^\s*PrintLastLog\s+
         state: absent
       when: dupes.found is defined and dupes.found > 1
-    - name: Insert correct line to /etc/ssh/sshd_config
+    - name: TOSS-04-020260 - Insert correct line to /etc/ssh/sshd_config
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config
         create: true

--- a/ansible/roles/stig/tasks/TOSS_04_020280.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020280.yml
@@ -17,14 +17,14 @@
 
 - name: TOSS-04-020280 - TOSS must not have unnecessary accounts.
   block:
-    - name: Get all /etc/passwd file entries
+    - name: TOSS-04-020280 - Get all /etc/passwd file entries
       ansible.builtin.getent:
         database: passwd
         split: ':'
-    - name: Create local_users variable from the getent output
+    - name: TOSS-04-020280 - Create local_users variable from the getent output
       ansible.builtin.set_fact:
         local_users: '{{ ansible_facts.getent_passwd | dict2items }}'
-    - name: List all accounts
+    - name: TOSS-04-020280 - List all accounts
       ansible.builtin.debug:
         var: local_users
         verbosity: 1

--- a/ansible/roles/stig/tasks/TOSS_04_020300.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020300.yml
@@ -10,14 +10,14 @@
 
 - name: TOSS-04-020300 - All TOSS local interactive user home directories must have mode 0770 or less permissive.
   block:
-    - name: Get all local users from /etc/passwd, ignoring any errors from directories that don't exist on this system
+    - name: TOSS-04-020300 - Get all local users from /etc/passwd, ignoring any errors from directories that don't exist on this system
       ansible.builtin.shell:
         cmd: "find $(awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/)&&($7 !~ /null/){print $6}' /etc/passwd) -xdev -maxdepth 0 -perm /007 2> /dev/null"
       register: local_users
       changed_when: false
       failed_when: local_users.rc not in [0,1]
       check_mode: false
-    - name: Ensure interactive local users have 0770 or less permissive on their respective home directories
+    - name: TOSS-04-020300 - Ensure interactive local users have 0770 or less permissive on their respective home directories
       ansible.builtin.file:
         path: '{{ item }}'
         mode: '770'

--- a/ansible/roles/stig/tasks/TOSS_04_020310.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020310.yml
@@ -8,14 +8,14 @@
 
 - name: TOSS-04-020310 - All TOSS local interactive user home directories must be owned by root.
   block:
-    - name: Get the list of home directories not owned by root, ignoring any errors from directories that don't exist on this system
+    - name: TOSS-04-020310 - Get the list of home directories not owned by root, ignoring any errors from directories that don't exist on this system
       ansible.builtin.shell:
         cmd: "find $(awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/)&&($7 !~ /null/){print $6}' /etc/passwd) -xdev -maxdepth 0 -not -user root 2> /dev/null"
       register: home_dirs
       changed_when: false
       failed_when: home_dirs.rc not in [0,1]
       check_mode: false
-    - name: Change the owner of the local interactive user's home directory
+    - name: TOSS-04-020310 - Change the owner of the local interactive user's home directory
       ansible.builtin.file:
         path: '{{ item }}'
         owner: root

--- a/ansible/roles/stig/tasks/TOSS_04_020320.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020320.yml
@@ -12,14 +12,14 @@
 
 - name: TOSS-04-020320 - All TOSS local interactive user home directories must be owned by the user's primary group.
   block:
-    - name: Get the list of home directories owned by interactive users
+    - name: TOSS-04-020320 - Get the list of home directories owned by interactive users
       ansible.builtin.shell:
         cmd: "awk -F: '($3>=1000)&&($7 !~ /nologin/)&&($7 !~ /false/)&&($7 !~ /null/){print $1,$6,$4}' /etc/passwd"
       register: home_dirs
       changed_when: false
       failed_when: home_dirs.rc not in [0,1]
       check_mode: false
-    - name: Set the group of the local interactive user's home directory
+    - name: TOSS-04-020320 - Set the group of the local interactive user's home directory
       ansible.builtin.file:
         path: '{{ item.split().1 }}'
         group: '{{ item.split().2 }}'

--- a/ansible/roles/stig/tasks/TOSS_04_030010.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030010.yml
@@ -10,11 +10,11 @@
 
 - name: TOSS-04-030010 - TOSS audit records must contain information to establish what type of events occurred, when the events occurred, the source of events, where events occurred, and the outcome of events.
   block:
-    - name: Ensure auditd package is installed
+    - name: TOSS-04-030010 - Ensure auditd package is installed
       ansible.builtin.package:
         name: audit
         state: present
-    - name: Enable auditd Service
+    - name: TOSS-04-030010 - Enable auditd Service
       ansible.builtin.systemd:
         name: auditd
         state: started

--- a/ansible/roles/stig/tasks/TOSS_04_030180.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030180.yml
@@ -8,7 +8,7 @@
 
 - name: TOSS-04-030180 - The TOSS audit system must protect auditing rules from unauthorized change.
   block:
-    - name: Check if '-e 2' is present to make the audit system immutable
+    - name: TOSS-04-030180 - Check if '-e 2' is present to make the audit system immutable
       ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -e 2

--- a/ansible/roles/stig/tasks/TOSS_04_030420.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030420.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-030420 - Successful/unsuccessful uses of the "init_module" command in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030420 - Successful/unsuccessful uses of "init_module" command, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S init_module -F auid>=1000 -F auid!=unset -k module_chng
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030420 - Successful/unsuccessful uses of "init_module" command, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S init_module -F auid>=1000 -F auid!=unset -k module_chng
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030430.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030430.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-030430 - Successful/unsuccessful uses of the "rename" command in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030430 - Successful/unsuccessful uses of "rename" command, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S rename -F auid>=1000 -F auid!=unset -k delete
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030430 - Successful/unsuccessful uses of "rename" command, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S rename -F auid>=1000 -F auid!=unset -k delete
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030440.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030440.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-030440 - Successful/unsuccessful uses of the "renameat" command in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030440 - Successful/unsuccessful uses of "renameat" command, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S renameat -F auid>=1000 -F auid!=unset -k delete
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030440 - Successful/unsuccessful uses of "renameat" command, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S renameat -F auid>=1000 -F auid!=unset -k delete
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030450.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030450.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-030450 - Successful/unsuccessful uses of the "rmdir" command in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030450 - Successful/unsuccessful uses of "rmdir" command in TOSS must generate an audit record, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S rmdir -F auid>=1000 -F auid!=unset -k delete
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030450 - Successful/unsuccessful uses of "rmdir" command in TOSS must generate an audit record, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S rmdir -F auid>=1000 -F auid!=unset -k delete
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030460.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030460.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-030460 - Successful/unsuccessful uses of the "unlink" command in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030460 - Successful/unsuccessful uses of "unlink" command, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S unlink -F auid>=1000 -F auid!=unset -k delete
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030460 - Successful/unsuccessful uses of "unlink" command, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S unlink -F auid>=1000 -F auid!=unset -k delete
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030470.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030470.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-030470 - Successful/unsuccessful uses of the "unlinkat" command in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030470 - Successful/unsuccessful uses of "unlinkat" command, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S unlinkat -F auid>=1000 -F auid!=unset -k delete
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030470 - Successful/unsuccessful uses of "unlinkat" command, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S unlinkat -F auid>=1000 -F auid!=unset -k delete
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030480.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030480.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-030480 - Successful/unsuccessful uses of the "finit_module" command in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030480 - Successful/unsuccessful uses of "finit_module" command in TOSS must generate an audit record, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S finit_module -F auid>=1000 -F auid!=unset -k module_chng
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030480 - Successful/unsuccessful uses of "finit_module" command in TOSS must generate an audit record, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S finit_module -F auid>=1000 -F auid!=unset -k module_chng
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030490.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030490.yml
@@ -12,11 +12,13 @@
 
 - name: TOSS-04-030490 - Successful/unsuccessful uses of the "delete_module" command in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030490 - Successful/unsuccessful uses of "delete_module" command in TOSS must generate an audit record, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S delete_module -F auid>=1000 -F auid!=unset -k module_chng
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030490 - Successful/unsuccessful uses of "delete_module" command in TOSS must generate an audit record, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S delete_module -F auid>=1000 -F auid!=unset -k module_chng
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030550.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030550.yml
@@ -11,13 +11,13 @@
 
 - name: TOSS-04-030550 - TOSS must allow only the Information System Security Manager (ISSM) (or individuals or roles appointed by the ISSM) to select which auditable events are to be audited.
   block:
-    - name: Gather any file paths in "/etc/audit/rules.d/" and "/etc/audit/auditd.conf" file that have a mode of "0640" or less permissive
+    - name: TOSS-04-030550 - Gather any file paths in "/etc/audit/rules.d/" and "/etc/audit/auditd.conf" file that have a mode of "0640" or less permissive
       ansible.builtin.command: "find /etc/audit/rules.d/ /etc/audit/auditd.conf -xdev -maxdepth 1 -perm /037"
       register: audit_paths
       changed_when: false
       failed_when: audit_paths.rc not in [0,1]
       check_mode: false
-    - name: Set the file permissions to '0640'
+    - name: TOSS-04-030550 - Set the file permissions to '0640'
       ansible.builtin.file:
         path: '{{ item }}'
         mode: '0640'

--- a/ansible/roles/stig/tasks/TOSS_04_030560.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030560.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-030560 - Successful/unsuccessful uses of the chmod system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030560 - Successful/unsuccessful uses of the chmod system call, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030560 - Successful/unsuccessful uses of the chmod system call, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030570.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030570.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-030570 - Successful/unsuccessful uses of the chown system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030570 - Successful/unsuccessful uses of the chown system call, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030570 - Successful/unsuccessful uses of the chown system call, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030580.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030580.yml
@@ -14,19 +14,23 @@
 
 - name: TOSS-04-030580 - Successful/unsuccessful uses of the creat system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030580 - Successful/unsuccessful uses of the creat system call, esp. arch=b32 and EPERM exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030580 - Successful/unsuccessful uses of the creat system call, esp. arch=b64 and EPERM exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030580 - Successful/unsuccessful uses of the creat system call, esp. arch=b32 amd EACCES exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030580 - Successful/unsuccessful uses of the creat system call, esp. arch=b64 amd EACCES exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030590.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030590.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-030590 - Successful/unsuccessful uses of the fchmod system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030590 - Successful/unsuccessful uses of the fchmod system call, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S fchmod -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030590 - Successful/unsuccessful uses of the fchmod system call, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S fchmod -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030600.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030600.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-030600 - Successful/unsuccessful uses of the fchmodat system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030600 - Successful/unsuccessful uses of the fchmodat system call, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030600 - Successful/unsuccessful uses of the fchmodat system call, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030610.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030610.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-030610 - Successful/unsuccessful uses of the fchown system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030610 - Successful/unsuccessful uses of the fchown system call, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030610 - Successful/unsuccessful uses of the fchown system call, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030620.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030620.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-030620 - Successful/unsuccessful uses of the fchownat system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030620 - Successful/unsuccessful uses of the fchownat system call, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S fchownat -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030620 - Successful/unsuccessful uses of the fchownat system call, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S fchownat -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030630.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030630.yml
@@ -15,19 +15,23 @@
 
 - name: TOSS-04-030630 - Successful/unsuccessful uses of the ftruncate system call system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030630 - Successful/unsuccessful uses of the ftruncate system call, esp. arch=b32 and EPERM exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030630 - Successful/unsuccessful uses of the ftruncate system call, esp. arch=b64 and EPERM exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030630 - Successful/unsuccessful uses of the ftruncate system call, esp. arch=b32 and EACCES exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030630 - Successful/unsuccessful uses of the ftruncate system call, esp. arch=b64 and EACCES exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030640.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030640.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-030640 - Successful/unsuccessful uses of the lchown system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030640 - Successful/unsuccessful uses of the lchown system call, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S lchown -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030640 - Successful/unsuccessful uses of the lchown system call, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S lchown -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030650.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030650.yml
@@ -14,19 +14,23 @@
 
 - name: TOSS-04-030650 - Successful/unsuccessful uses of the open system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030650 - Successful/unsuccessful uses of the open system call, esp. arch=b32 and EPERM exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030650 - Successful/unsuccessful uses of the open system call, esp. arch=b64 and EPERM exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030650 - Successful/unsuccessful uses of the open system call, esp. arch=b32 and EACCES exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030650 - Successful/unsuccessful uses of the open system call, esp. arch=b64 and EACCES exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030660.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030660.yml
@@ -15,19 +15,23 @@
 
 - name: TOSS-04-030660 - Successful/unsuccessful uses of the open_by_handle_at system call system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030660 - Successful/unsuccessful uses of the open_by_handle_at system call, esp. arch=b32 and EPERM exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030660 - Successful/unsuccessful uses of the open_by_handle_at system call, esp. arch=b64 and EPERM exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030660 - Successful/unsuccessful uses of the open_by_handle_at system call, esp. arch=b32 and EACCES exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030660 - Successful/unsuccessful uses of the open_by_handle_at system call, esp. arch=b64 and EACCES exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030670.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030670.yml
@@ -14,19 +14,23 @@
 
 - name: TOSS-04-030670 - Successful/unsuccessful uses of the openat system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030670 - Successful/unsuccessful uses of the openat system call, esp. arch=b32 and EPERM exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030670 - Successful/unsuccessful uses of the openat system call, esp. arch=b64 and EPERM exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030670 - Successful/unsuccessful uses of the openat system call, esp. arch=b32 and EACCES exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030670 - Successful/unsuccessful uses of the openat system call, esp. arch=b64 and EACCES exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030680.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030680.yml
@@ -15,19 +15,23 @@
 
 - name: TOSS-04-030680 - Successful/unsuccessful uses of the truncate system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030680 - Successful/unsuccessful uses of the openat system call, esp. arch=b32 and EPERM exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030680 - Successful/unsuccessful uses of the openat system call, esp. arch=b64 and EPERM exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030680 - Successful/unsuccessful uses of the openat system call, esp. arch=b32 and EACCES exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030680 - Successful/unsuccessful uses of the openat system call, esp. arch=b64 and EACCES exit
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030780.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030780.yml
@@ -18,7 +18,7 @@
 # If any of the audit tools are not installed on the system, the corresponding
 # AIDE rule is not applicable.
 
-- name: Set audit_tools fact
+- name: TOSS-04-030780 - Set audit_tools fact
   ansible.builtin.set_fact:
     audit_tools:
       - /usr/sbin/auditctl

--- a/ansible/roles/stig/tasks/TOSS_04_030860.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030860.yml
@@ -13,19 +13,23 @@
 
 - name: TOSS-04-030860 - The TOSS audit system must prevent all software from executing at higher privilege levels than users executing the software and the audit system must be configured to audit the execution of privileged functions.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030860 - The TOSS audit system must prevent all software from executing at higher privilege levels than users executing the software and the audit system must be configured to audit the execution of privileged functions, esp arch=b32 and uid!=euid
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k execpriv
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030860 - The TOSS audit system must prevent all software from executing at higher privilege levels than users executing the software and the audit system must be configured to audit the execution of privileged functions, esp arch=b64 and uid!=euid
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k execpriv
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030860 - The TOSS audit system must prevent all software from executing at higher privilege levels than users executing the software and the audit system must be configured to audit the execution of privileged functions, esp arch=b32 and uid!=egid
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k execpriv
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030860 - The TOSS audit system must prevent all software from executing at higher privilege levels than users executing the software and the audit system must be configured to audit the execution of privileged functions, esp arch=b64 and uid!=egid
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k execpriv
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_030890.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030890.yml
@@ -21,30 +21,30 @@
 
 - name: TOSS-04-030890 - TOSS must allocate audit record storage capacity to store at least one week's worth of audit records, when audit records are not immediately sent to a central audit record storage facility.
   block:
-    - name: Determine to which partition the audit records are being written
+    - name: TOSS-04-030890 - Determine to which partition the audit records are being written
       ansible.builtin.command: "grep log_file /etc/audit/auditd.conf"
       changed_when: false
       check_mode: false
       failed_when: log_file.rc not in [0,1]
       register: log_file
-    - name: Get the size of the partition to which audit records are written
+    - name: TOSS-04-030890 - Get the size of the partition to which audit records are written
       ansible.builtin.command: "df -h {{ log_file.stdout.split().2 }}"
       changed_when: false
       check_mode: false
       register: disk_space
-    - name: Get the basename of the partition path
+    - name: TOSS-04-030890 - Get the basename of the partition path
       ansible.builtin.set_fact:
         audit_partition: '{{ log_file.stdout.split().2 | ansible.builtin.dirname }}'
-    - name: Determine the amount of space being used by other files in the partition
+    - name: TOSS-04-030890 - Determine the amount of space being used by other files in the partition
       ansible.builtin.command: "du -sh {{ audit_partition }}"
       changed_when: false
       check_mode: false
       register: disk_space_partition
-    - name: Display size of the partition audit records are written to
+    - name: TOSS-04-030890 - Display size of the partition audit records are written to
       ansible.builtin.debug:
         var: disk_space.stdout
         verbosity: 1
-    - name: Display the amount of space being used by the other files in the partition
+    - name: TOSS-04-030890 - Display the amount of space being used by the other files in the partition
       ansible.builtin.debug:
         var: disk_space_partition.stdout
         verbosity: 1

--- a/ansible/roles/stig/tasks/TOSS_04_030900.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030900.yml
@@ -11,8 +11,8 @@
 
 - name: TOSS-04-030900 - The TOSS audit records must be off-loaded onto a different system or storage media from the system being audited.
   block:
-    - name: Get the remote server the system is configured to offload audit records to
-      ansible.builtin.command: "grep @@ /etc/rsyslog.conf /etc/rsyslog.d/syslog_server.conf"
+    - name: TOSS-04-030900 - Get the remote server the system is configured to offload audit records to
+      ansible.builtin.shell: "grep @@ /etc/rsyslog.conf /etc/rsyslog.d/*.conf | grep -v '#'"
       changed_when: false
       check_mode: false
       failed_when: remote_logging.rc not in [0,1]
@@ -23,7 +23,6 @@
           - remote_logging.rc == 0
         fail_msg: "Audit logs are not being offoaded to a remote server via rsyslog, ask the System Administrator if logs are being offloaded a different way."
         quiet: true
-
   when:
     - toss_04_030900 | bool
   tags:

--- a/ansible/roles/stig/tasks/TOSS_04_030910.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030910.yml
@@ -9,7 +9,7 @@
 
 - name: TOSS-04-030910 - TOSS must label all off-loaded audit logs before sending them to the central log server.
   block:
-    - name: Check for duplicate values
+    - name: TOSS-04-030910 - Check for duplicate values
       ansible.builtin.lineinfile:
         path: /etc/audit/auditd.conf
         create: false
@@ -18,14 +18,14 @@
       check_mode: true
       changed_when: false
       register: dupes
-    - name: Deduplicate values from /etc/audit/auditd.conf
+    - name: TOSS-04-030910 - Deduplicate values from /etc/audit/auditd.conf
       ansible.builtin.lineinfile:
         path: /etc/audit/auditd.conf
         create: false
         regexp: (?i)^\s*name_format\s*=\s*
         state: absent
       when: dupes.found is defined and dupes.found > 1
-    - name: Insert correct line to /etc/audit/auditd.conf
+    - name: TOSS-04-030910 - Insert correct line to /etc/audit/auditd.conf
       ansible.builtin.lineinfile:
         path: /etc/audit/auditd.conf
         create: true

--- a/ansible/roles/stig/tasks/TOSS_04_030990.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030990.yml
@@ -12,19 +12,23 @@
 
 - name: TOSS-04-030990 - The TOSS audit system must be configured to audit any usage of the "fsetxattr" system call.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030990 - The TOSS audit system must be configured to audit any usage of the "fsetxattr" system call, esp. arch=b32 and auid!=unset
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030990 - The TOSS audit system must be configured to audit any usage of the "fsetxattr" system call, esp. arch=b64 and auid!=unset
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030990 - The TOSS audit system must be configured to audit any usage of the "fsetxattr" system call, esp. arch=b32 and auid=0
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S fsetxattr -F auid=0 -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-030990 - The TOSS audit system must be configured to audit any usage of the "fsetxattr" system call, esp. arch=b64 and auid=0
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S fsetxattr -F auid=0 -k perm_mod
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_031000.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031000.yml
@@ -12,19 +12,23 @@
 
 - name: TOSS-04-031000 - The TOSS audit system must be configured to audit any usage of the "lsetxattr" system call.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031000 - The TOSS audit system must be configured to audit any usage of the "lsetxattr" system call, esp. arch=b32 and auid!=unset
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031000 - The TOSS audit system must be configured to audit any usage of the "lsetxattr" system call, esp. arch=b64 and auid!=unset
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031000 - The TOSS audit system must be configured to audit any usage of the "lsetxattr" system call, esp. arch=b32 and auid=0
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S lsetxattr -F auid=0 -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031000 - The TOSS audit system must be configured to audit any usage of the "lsetxattr" system call, esp. arch=b64 and auid=0
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S lsetxattr -F auid=0 -k perm_mod
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_031100.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031100.yml
@@ -12,19 +12,23 @@
 
 - name: TOSS-04-031100 - Successful/unsuccessful uses of the fremovexattr system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031100 - Successful/unsuccessful uses of the fremovexattr system call in TOSS must generate an audit record, esp. arch=b32 and auid!=unset
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031100 - Successful/unsuccessful uses of the fremovexattr system call in TOSS must generate an audit record, esp. arch=b64 and auid!=unset
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031100 - Successful/unsuccessful uses of the fremovexattr system call in TOSS must generate an audit record, esp. arch=b32 and auid=0
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S fremovexattr -F auid=0 -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031100 - Successful/unsuccessful uses of the fremovexattr system call in TOSS must generate an audit record, esp. arch=b64 and auid=0
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S fremovexattr -F auid=0 -k perm_mod
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_031110.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031110.yml
@@ -12,19 +12,23 @@
 
 - name: TOSS-04-031110 - Successful/unsuccessful uses of the "lremovexattr" system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031110 - Successful/unsuccessful uses of the "lremovexattr" system call in TOSS must generate an audit record, esp. arch=b32 and auid!=unset
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031110 - Successful/unsuccessful uses of the "lremovexattr" system call in TOSS must generate an audit record, esp. arch=b64 and auid!=unset
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031110 - Successful/unsuccessful uses of the "lremovexattr" system call in TOSS must generate an audit record, esp. arch=b32 and auid=0
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S lremovexattr -F auid=0 -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031110 - Successful/unsuccessful uses of the "lremovexattr" system call in TOSS must generate an audit record, esp. arch=b64 and auid=0
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S lremovexattr -F auid=0 -k perm_mod
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_031120.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031120.yml
@@ -12,19 +12,23 @@
 
 - name: TOSS-04-031120 - Successful/unsuccessful uses of the "removexattr" system call in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031120 - Successful/unsuccessful uses of the "removexattr" system call in TOSS must generate an audit record, esp. arch=b32 and auid!=unset
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S removexattr -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031120 - Successful/unsuccessful uses of the "removexattr" system call in TOSS must generate an audit record, esp. arch=b64 and auid!=unset
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S removexattr -F auid>=1000 -F auid!=unset -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031120 - Successful/unsuccessful uses of the "removexattr" system call in TOSS must generate an audit record, esp. arch=b32 and auid=0
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S removexattr -F auid=0 -k perm_mod
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031120 - Successful/unsuccessful uses of the "removexattr" system call in TOSS must generate an audit record, esp. arch=b64 and auid=0
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S removexattr -F auid=0 -k perm_mod
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_031170.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031170.yml
@@ -11,11 +11,13 @@
 
 - name: TOSS-04-031170 - Successful/unsuccessful uses of the "mount" syscall in TOSS must generate an audit record.
   block:
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031170 - Successful/unsuccessful uses of the "mount" syscall in TOSS must generate an audit record, esp. arch=b32
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=unset -k privileged
       notify: Build auditd rules
-    - ansible.builtin.lineinfile:
+    - name: TOSS-04-031170 - Successful/unsuccessful uses of the "mount" syscall in TOSS must generate an audit record, esp. arch=b64
+      ansible.builtin.lineinfile:
         path: /etc/audit/rules.d/audit.rules
         line: -a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=unset -k privileged
       notify: Build auditd rules

--- a/ansible/roles/stig/tasks/TOSS_04_040010.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040010.yml
@@ -9,7 +9,7 @@
 
 - name: TOSS-04-040010 - TOSS must monitor remote access methods.
   block:
-    - name: 'Set facts'
+    - name: 'TOSS-04-040010 - Set facts'
       ansible.builtin.set_fact:
         conf_files:
           - /etc/rsyslog.conf
@@ -20,23 +20,23 @@
             regexp: ^.*authpriv\.\*.*$
           - selector: daemon.*
             regexp: ^.*daemon\.\*.*$
-    - name: 'Ensure rsyslog.conf exists'
+    - name: 'TOSS-04-040010 - Ensure rsyslog.conf exists'
       ansible.builtin.file:
         path: '{{ conf_files.0 }}'
         state: touch
         mode: '0644'
-    - name: 'Gather conf.d files'
+    - name: 'TOSS-04-040010 - Gather conf.d files'
       ansible.builtin.find:
         patterns:
           - '*.conf'
         paths:
           - /etc/rsyslog.d
       register: rsyslogd
-    - name: 'Set conf file(s)'
+    - name: 'TOSS-04-040010 - Set conf file(s)'
       ansible.builtin.set_fact:
         conf_files: '{{ conf_files + [item.path] }}'
       loop: '{{ rsyslogd.files }}'
-    - name: 'Check for existing values'
+    - name: 'TOSS-04-040010 - Check for existing values'
       ansible.builtin.lineinfile:
         path: '{{ item.1 }}'
         regexp: '{{ item.0.regexp }}'
@@ -45,7 +45,7 @@
       changed_when: false
       register: remote_method_values
       loop: '{{ remote_methods | product(conf_files) | list }}'
-    - name: 'Configure'
+    - name: 'TOSS-04-040010 - Configure'
       ansible.builtin.lineinfile:
         path: /etc/rsyslog.conf
         regexp: '{{ item.item.0.regexp }} .*\/var\/log\/secure.*$'

--- a/ansible/roles/stig/tasks/TOSS_04_040020.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040020.yml
@@ -9,7 +9,7 @@
 
 - name: TOSS-04-040020 - TOSS must force a frequent session key renegotiation for SSH connections by the client.
   block:
-    - name: Check for duplicate values
+    - name: TOSS-04-040020 - Check for duplicate values
       ansible.builtin.lineinfile:
         path: /etc/ssh/ssh_config
         create: false
@@ -18,14 +18,14 @@
       check_mode: true
       changed_when: false
       register: dupes
-    - name: Deduplicate values from /etc/ssh/ssh_config
+    - name: TOSS-04-040020 - Deduplicate values from /etc/ssh/ssh_config
       ansible.builtin.lineinfile:
         path: /etc/ssh/ssh_config
         create: false
         regexp: (?i)^\s*RekeyLimit\s+
         state: absent
       when: dupes.found is defined and dupes.found > 1
-    - name: Insert correct line to /etc/ssh/ssh_config
+    - name: TOSS-04-040020 - Insert correct line to /etc/ssh/ssh_config
       ansible.builtin.lineinfile:
         path: /etc/ssh/ssh_config
         create: true

--- a/ansible/roles/stig/tasks/TOSS_04_040030.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040030.yml
@@ -9,7 +9,7 @@
 
 - name: TOSS-04-040030 - TOSS must force a frequent session key renegotiation for SSH connections to the server.
   block:
-    - name: Check for duplicate values
+    - name: TOSS-04-040030 - Check for duplicate values
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config
         create: false
@@ -18,14 +18,14 @@
       check_mode: true
       changed_when: false
       register: dupes
-    - name: Deduplicate values from /etc/ssh/sshd_config
+    - name: TOSS-04-040030 - Deduplicate values from /etc/ssh/sshd_config
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config
         create: false
         regexp: (?i)^\s*RekeyLimit\s+
         state: absent
       when: dupes.found is defined and dupes.found > 1
-    - name: Insert correct line to /etc/ssh/sshd_config
+    - name: TOSS-04-040030 - Insert correct line to /etc/ssh/sshd_config
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config
         create: true

--- a/ansible/roles/stig/tasks/TOSS_04_040040.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040040.yml
@@ -20,28 +20,28 @@
 
 - name: TOSS-04-040040 - TOSS must implement NIST FIPS-validated cryptography for the following to provision digital signatures; to generate cryptographic hashes; and to protect unclassified information requiring confidentiality and cryptographic protection in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.
   block:
-    - name: Check to see the current status of FIPS mode
+    - name: TOSS-04-040040 - Check to see the current status of FIPS mode
       ansible.builtin.command: /usr/bin/fips-mode-setup --check
       register: is_fips_enabled
       check_mode: false
       changed_when: false
-    - name: Enable FIPS mode
+    - name: TOSS-04-040040 - Enable FIPS mode
       ansible.builtin.command: /usr/bin/fips-mode-setup --enable
       # Note: Running this command will create a symlink from opensshserver.config and openssh.config to other files,  making permission look like '0777' to ansible's checks
       changed_when: fips_setup_output.rc is defined
       when: is_fips_enabled.stdout.find('FIPS mode is enabled.') == -1
       register: fips_setup_output
-    - name: Check to see if the kernel boot parameter is configured for FIPS mode
+    - name: TOSS-04-040040 - Check to see if the kernel boot parameter is configured for FIPS mode
       ansible.builtin.command: grub2-editenv list
       register: boot_param
       check_mode: false
       changed_when: false
-    - name: Check to see if the system is in FIPS mode
+    - name: TOSS-04-040040 - Check to see if the system is in FIPS mode
       ansible.builtin.command: cat /proc/sys/crypto/fips_enabled
       register: system_mode
       changed_when: false
       check_mode: false
-    - name: Fail when kernel boot param is not configured for FIPS mode
+    - name: TOSS-04-040040 - Fail when kernel boot param is not configured for FIPS mode
       ansible.builtin.assert:
         that:
           - boot_param.stdout.find("fips=1")

--- a/ansible/roles/stig/tasks/TOSS_04_040150.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040150.yml
@@ -27,7 +27,7 @@
 
 - name: TOSS-04-040150 - TOSS must cover or disable the built-in or attached camera when not in use.
   block:
-    - name: Determine if the camera is disabled via blacklist
+    - name: TOSS-04-040150 - Determine if the camera is disabled via blacklist
       ansible.builtin.command: grep -P '^blacklist[\s,\S]*video' {{ item }}
       check_mode: false
       changed_when: false
@@ -35,17 +35,17 @@
       register: blacklists
       with_fileglob:
         - "/etc/modprobe.d/*"
-    - name: Display all blacklisted drivers
+    - name: TOSS-04-040150 - Display all blacklisted drivers
       ansible.builtin.debug:
         var: blacklists.stdout_lines
         verbosity: 1
-    - name: Determine the driver being used by the camera
+    - name: TOSS-04-040150 - Determine the driver being used by the camera
       ansible.builtin.command: "dmesg | grep -i video"
       check_mode: false
       changed_when: false
       failed_when: drivers.rc not in [0,1]
       register: drivers
-    - name: Display all video drivers, if the camera driver blacklist is missing, add it to the "/etc/modprobe.d/blacklist.conf" file
+    - name: TOSS-04-040150 - Display all video drivers, if the camera driver blacklist is missing, add it to the "/etc/modprobe.d/blacklist.conf" file
       ansible.builtin.debug:
         var: drivers.stdout_lines
         verbosity: 1

--- a/ansible/roles/stig/tasks/TOSS_04_040160.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040160.yml
@@ -17,14 +17,14 @@
 
 - name: TOSS-04-040160 - TOSS must disable IEEE 1394 (FireWire) Support.
   block:
-    - name: TOSS-04-040190 - TOSS must disable IEEE 1394 (FireWire) Support. Check install.
+    - name: TOSS-04-040160 - TOSS must disable IEEE 1394 (FireWire) Support. Check install.
       ansible.builtin.lineinfile:
         create: true
         dest: /etc/modprobe.d/firewire-core.conf
         regexp: install\s+firewire-core
         line: install firewire-core /bin/false
         mode: '644'
-    - name: TOSS-04-040190 - TOSS must disable IEEE 1394 (FireWire) Support. Check blacklist.
+    - name: TOSS-04-040160 - TOSS must disable IEEE 1394 (FireWire) Support. Check blacklist.
       ansible.builtin.lineinfile:
         create: true
         dest: /etc/modprobe.d/blacklist-firewire-core.conf

--- a/ansible/roles/stig/tasks/TOSS_04_040170.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040170.yml
@@ -16,14 +16,14 @@
 
 - name: TOSS-04-040170 - TOSS must disable mounting of cramfs.
   block:
-    - name: TOSS-04-040190 - TOSS must disable mounting of cramfs. Check install.
+    - name: TOSS-04-040170 - TOSS must disable mounting of cramfs. Check install.
       ansible.builtin.lineinfile:
         create: true
         dest: /etc/modprobe.d/cramfs.conf
         regexp: install\s+cramfs
         line: install cramfs /bin/false
         mode: '644'
-    - name: TOSS-04-040190 - TOSS must disable mounting of cramfs. Check blacklist.
+    - name: TOSS-04-040170 - TOSS must disable mounting of cramfs. Check blacklist.
       ansible.builtin.lineinfile:
         create: true
         dest: /etc/modprobe.d/blacklist-cramfs.conf

--- a/ansible/roles/stig/tasks/TOSS_04_040270.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040270.yml
@@ -17,11 +17,11 @@
 
 - name: TOSS-04-040270 - TOSS must be configured to prohibit or restrict the use of functions, ports, protocols, and/or services, as defined in the PPSM CAL and vulnerability assessments.
   block:
-    - name: Gather information about active zones
+    - name: TOSS-04-040270 - Gather information about active zones
       ansible.posix.firewalld_info:
         active_zones: true
       register: result
-    - name: List all zones
+    - name: TOSS-04-040270 - List all zones
       ansible.builtin.debug:
         var: result.firewalld_info.zones
         verbosity: 1

--- a/ansible/roles/stig/tasks/TOSS_04_040290.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040290.yml
@@ -14,7 +14,7 @@
 
 - name: TOSS-04-040290 - TOSS must be configured so that all network connections associated with SSH traffic are terminated at the end of the session or after 10 minutes of inactivity, except to fulfill documented and validated mission requirements.
   block:
-    - name: TOSS-04-040290
+    - name: TOSS-04-040290 - check "ClientAliveInterval" is set to a value of "600" or less
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config
         regexp: '^(?i)#?ClientAliveInterval'
@@ -23,7 +23,7 @@
         backup: true
         validate: /usr/sbin/sshd -t -f %s
       notify: Restart sshd
-    - name: TOSS-04-040290
+    - name: TOSS-04-040290 - check "ClientAliveCountMax" is set to a value of "1"
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config
         regexp: '^(?i)#?ClientAliveCountMax'

--- a/ansible/roles/stig/tasks/TOSS_04_040330.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040330.yml
@@ -13,12 +13,12 @@
 
 - name: TOSS-04-040330 - All TOSS local disk partitions must implement cryptographic mechanisms to prevent unauthorized disclosure or modification of all information that requires at rest protection.
   block:
-    - name: Gather the attributes of all local system partitions
+    - name: TOSS-04-040330 - Gather the attributes of all local system partitions
       ansible.builtin.command: "blkid"
       check_mode: false
       changed_when: false
       register: partitions
-    - name: Verify all local system partitions are encrypted
+    - name: TOSS-04-040330 - Verify all local system partitions are encrypted
       ansible.builtin.assert:
         that:
           - "'crypto_LUKS' in item"

--- a/ansible/roles/stig/tasks/TOSS_04_040340.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040340.yml
@@ -14,24 +14,24 @@
 
 - name: TOSS-04-040340 - TOSS must limit privileges to change software resident within software libraries.
   block:
-    - name: Read list of system executables without root ownership
+    - name: TOSS-04-040340 - Read list of system executables without root ownership
       ansible.builtin.command: find -L /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ /usr/libexec \! -user root
       register: no_root_system_executables
       changed_when: false
       failed_when: false
       check_mode: false
-    - name: Set ownership to root of system executables
+    - name: TOSS-04-040340 - Set ownership to root of system executables
       ansible.builtin.file:
         path: '{{ item }}'
         owner: root
       loop: '{{ no_root_system_executables.stdout_lines }}'
-    - name: Read list of library files without root ownership
+    - name: TOSS-04-040340 - Read list of library files without root ownership
       ansible.builtin.command: find -L /lib /lib64 /usr/lib /usr/lib64 \! -user root
       register: no_root_library_files
       changed_when: false
       failed_when: false
       check_mode: false
-    - name: Set ownership to root of library files
+    - name: TOSS-04-040340 - Set ownership to root of library files
       ansible.builtin.file:
         path: '{{ item }}'
         owner: root

--- a/ansible/roles/stig/tasks/TOSS_04_040370.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040370.yml
@@ -9,11 +9,11 @@
 
 - name: TOSS-04-040370 - A firewall must be installed on TOSS.
   block:
-    - name: Ensure firewalld is installed
+    - name: TOSS-04-040370 - Ensure firewalld is installed
       ansible.builtin.package:
         name: firewalld
         state: present
-    - name: Ensure firewalld is enabled / active
+    - name: TOSS-04-040370 - Ensure firewalld is enabled / active
       ansible.builtin.systemd:
         name: firewalld
         enabled: true

--- a/ansible/roles/stig/tasks/TOSS_04_040390.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040390.yml
@@ -12,7 +12,7 @@
 
 - name: TOSS-04-040390 - TOSS must take appropriate action when the internal event queue is full.
   block:
-    - name: Check for duplicate values
+    - name: TOSS-04-040390 - Check for duplicate values
       ansible.builtin.lineinfile:
         path: /etc/audit/auditd.conf
         create: false
@@ -21,14 +21,14 @@
       check_mode: true
       changed_when: false
       register: dupes
-    - name: Deduplicate values from /etc/audit/auditd.conf
+    - name: TOSS-04-040390 - Deduplicate values from /etc/audit/auditd.conf
       ansible.builtin.lineinfile:
         path: /etc/audit/auditd.conf
         create: false
         regexp: (?i)^\s*overflow_action\s*=\s*
         state: absent
       when: dupes.found is defined and dupes.found > 1
-    - name: Insert correct line to /etc/audit/auditd.conf
+    - name: TOSS-04-040390 - Insert correct line to /etc/audit/auditd.conf
       ansible.builtin.lineinfile:
         path: /etc/audit/auditd.conf
         create: true

--- a/ansible/roles/stig/tasks/TOSS_04_040420.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040420.yml
@@ -11,11 +11,11 @@
 
 - name: TOSS-04-040420 - TOSS must accept Personal Identity Verification (PIV) credentials.
   block:
-    - name: Ensure opensc is installed
+    - name: TOSS-04-040420 - Ensure opensc is installed
       ansible.builtin.package:
         name: opensc
         state: present
-    - name: Ensure opensc accepts PIV cards
+    - name: TOSS-04-040420 - Ensure opensc accepts PIV cards
       ansible.builtin.shell: "set -o pipefail && opensc-tool --list-drivers | grep -i piv"
       changed_when: false
       check_mode: false

--- a/ansible/roles/stig/tasks/TOSS_04_040440.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040440.yml
@@ -13,19 +13,19 @@
 
 - name: TOSS-04-040440 - TOSS must implement DoD-approved encryption in the OpenSSL package.
   block:
-    - name: Verify that system-wide crypto policies are in effect
+    - name: TOSS-04-040440 - Verify that system-wide crypto policies are in effect
       ansible.builtin.lineinfile:
         path: /etc/pki/tls/openssl.cnf
         regexp: '^.include /etc/crypto-policies/back-ends/opensslcnf.config'
         line: ".include /etc/crypto-policies/back-ends/opensslcnf.config"
         mode: '0644'
         create: true
-    - name: Check which system-wide crypto policy is in use
+    - name: TOSS-04-040440 - Check which system-wide crypto policy is in use
       ansible.builtin.command: update-crypto-policies --show
       register: crypto_policy_output
       changed_when: false
       check_mode: false
-    - name: Configure the TOSS OpenSSL library to use only ciphers employing FIPS 140-2-approved algorithms
+    - name: TOSS-04-040440 - Configure the TOSS OpenSSL library to use only ciphers employing FIPS 140-2-approved algorithms
       ansible.builtin.command: fips-mode-setup --enable
       # Note: Running this command will create a symlink from opensshserver.config and openssh.config to other files,  making permission look like '0777' to ansible's checks
       changed_when: fips_setup_output.rc is defined

--- a/ansible/roles/stig/tasks/TOSS_04_040490.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040490.yml
@@ -11,20 +11,20 @@
 
 - name: TOSS-04-040490 - TOSS must implement non-executable data to protect its memory from unauthorized code execution.
   block:
-    - name: Check that the no-execution bit flag is set
+    - name: TOSS-04-040490 - Check that the no-execution bit flag is set
       ansible.builtin.shell:
         cmd: 'set -o pipefail && dmesg | grep "NX (Execute Disable) protection: active"'
       register: execute_bit_flag
       failed_when: execute_bit_flag.rc not in [0, 1]
       changed_when: false
       check_mode: false
-    - name: Check the cpuinfo settings for the nx flag
+    - name: TOSS-04-040490 - Check the cpuinfo settings for the nx flag
       ansible.builtin.command: 'grep -i "flags\(\s\|\S\)\+nx" /proc/cpuinfo'
       register: cpuinfo_settings
       failed_when: cpuinfo_settings.rc not in [0, 1]
       when: execute_bit_flag.rc == 1
       changed_when: false
-    - name: Check that both flags are set
+    - name: TOSS-04-040490 - Check that both flags are set
       ansible.builtin.assert:
         that:
           - execute_bit_flag.rc == 0 or cpuinfo_settings.rc == 0

--- a/ansible/roles/stig/tasks/TOSS_04_040560.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040560.yml
@@ -9,7 +9,7 @@
 
 - name: TOSS-04-040560 - A File Transfer Protocol (FTP) server package must not be installed unless mission essential on TOSS.
   block:
-    - name: Ensure vsftpd is removed
+    - name: TOSS-04-040560 - Ensure vsftpd is removed
       ansible.builtin.package:
         name: vsftpd
         state: absent

--- a/ansible/roles/stig/tasks/TOSS_04_040570.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040570.yml
@@ -10,13 +10,13 @@
 
 - name: TOSS-04-040570 - All TOSS local files and directories must have a valid group owner.
   block:
-    - name: Verify all local files and directories on TOSS have a valid group
+    - name: TOSS-04-040570 - Verify all local files and directories on TOSS have a valid group
       ansible.builtin.command: "find / -xdev -nogroup"
       register: nogroup_files
       changed_when: false
       check_mode: false
       failed_when: "nogroup_files.rc not in [0,1]"
-    - name: Assign files and directories without a group to root # TODO check if this is the right thing to do vs deleting or different group
+    - name: TOSS-04-040570 - Assign files and directories without a group to root # TODO check if this is the right thing to do vs deleting or different group
       ansible.builtin.file:
         path: '{{ item }}'
         group: root

--- a/ansible/roles/stig/tasks/TOSS_04_040580.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040580.yml
@@ -10,13 +10,13 @@
 
 - name: TOSS-04-040580 - All TOSS local files and directories must have a valid owner.
   block:
-    - name: Verify all local files and directories on TOSS have a valid owner
+    - name: TOSS-04-040580 - Verify all local files and directories on TOSS have a valid owner
       ansible.builtin.command: "find / -xdev -nouser"
       register: nouser_files
       changed_when: false
       check_mode: false
       failed_when: "nouser_files.rc not in [0,1]"
-    - name: Assign files and directories without an owner to root # TODO check if this is the right thing to do vs deleting or different user
+    - name: TOSS-04-040580 - Assign files and directories without an owner to root # TODO check if this is the right thing to do vs deleting or different user
       ansible.builtin.file:
         path: '{{ item }}'
         owner: root

--- a/ansible/roles/stig/tasks/TOSS_04_040590.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040590.yml
@@ -15,20 +15,20 @@
 
 - name: TOSS-04-040590 - Cron logging must be implemented in TOSS.
   block:
-    - name: Check that rsyslog is configured to log cron events
+    - name: TOSS-04-040590 - Check that rsyslog is configured to log cron events
       ansible.builtin.command: "grep -r cron /etc/rsyslog.conf /etc/rsyslog.d"
       changed_when: false
       check_mode: false
       failed_when: cron_output.rc not in [0,1]
       register: cron_output
-    - name: Check for cron logging all facilities
+    - name: TOSS-04-040590 - Check for cron logging all facilities
       ansible.builtin.command: "grep -r /var/log/messages /etc/rsyslog.conf /etc/rsyslog.d"
       changed_when: false
       check_mode: false
       failed_when: varlog_output.rc not in [0,1]
       register: varlog_output
       when: cron_output.rc != 0
-    - name: Configure "rsyslog" to log all cron messages
+    - name: TOSS-04-040590 - Configure "rsyslog" to log all cron messages
       ansible.builtin.lineinfile:
         path: /etc/rsyslog.conf
         line: "cron.* /var/log/cron"

--- a/ansible/roles/stig/tasks/TOSS_04_040600.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040600.yml
@@ -11,29 +11,44 @@
 
 - name: TOSS-04-040600 - If the Trivial File Transfer Protocol (TFTP) server is required, the TOSS TFTP daemon must be configured to operate in secure mode.
   block:
-    - name: Gather the package facts
+    - name: TOSS-04-040590 - Gather the package facts
       ansible.builtin.package_facts:
         manager: auto
-    - name: Find out if the file exists and contains the line configuring server arguments
-      ansible.builtin.find:
-        path: /etc/xinetd.d
-        patterns: tftp
-        contains: ^[\s]+server_args.*$
-      register: tftpd_secure_config_line
-    - name: Check if /etc/xinetd.d/tftp exists
-      ansible.builtin.stat:
-        path: /etc/xinetd.d/tftp
-      register: tftp_file
-      failed_when: not tftp_file.stat.exists
-    - name: If installed, Ensure that TFTP server is configured to start with secure directory
-      ansible.builtin.lineinfile:
-        path: /etc/xinetd.d/tftp
-        regexp: ^[\s]*(server_args[\s]+=[\s]+.*?)(-s[\s]+[/\.\w]+)*(.*)$
-        line: \1 -s {{ var_tftpd_secure_directory }} \3
-        state: present
-        backrefs: true
+    - name: TOSS-04-040590 - Verify the TFTP daemon is configured to operate in secure mode
+      block:
+        - name: TOSS-04-040590 - Check if /etc/xinetd.d/tftp exists
+          ansible.builtin.stat:
+            path: /etc/xinetd.d/tftp
+          register: xinetd_tftp_file
+        - name: TOSS-04-040590 - If /etc/xinetd.d/tftp exists, ensure that TFTP server is configured to start with secure directory
+          ansible.builtin.lineinfile:
+            path: /etc/xinetd.d/tftp
+            regexp: ^[\s]*(server_args[\s]*=[\s]*)(.*)$
+            line: \1-s {{ var_tftpd_secure_directory }}
+            state: present
+            backrefs: true
+          register: xinetd_tftp_setup
+          when:
+            - xinetd_tftp_file.stat.exists
+        - name: TOSS-04-040590 - If TFTP is not configured with xinetd, check systemd
+          block:
+            - name: TOSS-04-040590 - Check if /lib/systemd/system/tftp.service exists
+              ansible.builtin.stat:
+                path: /lib/systemd/system/tftp.service
+              register: systemd_tftp_file
+            - name: TOSS-04-040590 - If /lib/systemd/system/tftp.service exists, ensure that TFTP server is configured to start with secure directory
+              ansible.builtin.lineinfile:
+                path: /lib/systemd/system/tftp.service
+                regexp: ^[\s]*(ExecStart[\s]*=[\s]*)(.*)$
+                line: \1/usr/sbin/in.tftpd -s {{ var_tftpd_secure_directory }}
+                state: present
+                backrefs: true
+              register: systemd_tftp_setup
+              when:
+                - systemd_tftp_file.stat.exists
+          when:
+            - not xinetd_tftp_file.stat.exists or xinetd_tftp_setup.changed is defined
       when:
-        - tftp_file.stat.exists
         - '"tftp-server" in ansible_facts.packages'
   when:
     - toss_04_040600 | bool
@@ -46,3 +61,4 @@
     - medium_severity
     - CCI-000366
     - DISA-STIG-RHEL-08-040190
+    - toss_stig

--- a/ansible/roles/stig/tasks/TOSS_04_040660.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040660.yml
@@ -10,12 +10,14 @@
 
 - name: TOSS-04-040660 - The TOSS SSH private host key files must have mode 0600 or less permissive.
   block:
-    - ansible.builtin.find:
+    - name: TOSS-04-040660 - find SSH private host key
+      ansible.builtin.find:
         paths: /etc/ssh/
         file_type: file
         patterns: 'ssh_host*key'
       register: ssh_keys
-    - ansible.builtin.file:
+    - name: TOSS-04-040660 - verify SSH private host key files have mode "0600" or less
+      ansible.builtin.file:
         path: '{{ ssh_key.path }}'
         mode: '0600'
       loop: '{{ ssh_keys.files }}'

--- a/ansible/roles/stig/tasks/TOSS_04_040670.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040670.yml
@@ -11,12 +11,14 @@
 
 - name: TOSS-04-040670 - The TOSS SSH public host key files must have mode 0644 or less permissive.
   block:
-    - ansible.builtin.find:
+    - name: TOSS-04-040670 - find SSH public host key
+      ansible.builtin.find:
         paths: /etc/ssh/
         file_type: file
         patterns: '*.pub'
       register: ssh_keys
-    - ansible.builtin.file:
+    - name: TOSS-04-040670 - verify SSH public host key files have mode "0644" or less
+      ansible.builtin.file:
         path: '{{ ssh_key.path }}'
         mode: '0600'
       loop: '{{ ssh_keys.files }}'

--- a/ansible/roles/stig/tasks/TOSS_04_040690.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040690.yml
@@ -12,7 +12,7 @@
 
 - name: TOSS-04-040690 - TOSS must be a vendor-supported release.
   block:
-    - name: Get the current version of TOSS
+    - name: TOSS-04-040690 - Get the current version of TOSS
       ansible.builtin.shell:
         cmd: |
           set -o pipefail
@@ -20,13 +20,17 @@
       changed_when: false
       check_mode: false
       register: toss_version
-    - name: Check if the current version is supported
+    - name: TOSS-04-040690 - Check if the current version is supported
       ansible.builtin.assert:
         that:
           - toss_version.stdout in toss_end_of_support
           - now() < (toss_end_of_support[toss_version.stdout] | to_datetime)
         fail_msg: "TOSS {{ toss_version.stdout }}, is no longer supported. See https://hpc.llnl.gov/toss for supported versions"
         quiet: true
+  rescue:
+    - name: TOSS-04-040690 - ERROR - TOSS is not a vendor-supported release
+      ansible.builtin.debug:
+        msg: "TOSS {{ toss_version.stdout }}, is no longer supported. See https://hpc.llnl.gov/toss for supported versions"
   when:
     - toss_04_040690 | bool
   tags:

--- a/ansible/roles/stig/tasks/TOSS_04_040700.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040700.yml
@@ -13,7 +13,7 @@
 
 - name: TOSS-04-040700 - TOSS must be configured to prevent unrestricted mail relaying.
   block:
-    - name: Check for duplicate values
+    - name: TOSS-04-040700 - Check for duplicate values
       ansible.builtin.lineinfile:
         path: /etc/postfix/main.cf
         create: false
@@ -22,14 +22,14 @@
       check_mode: true
       changed_when: false
       register: dupes
-    - name: Deduplicate values from /etc/postfix/main.cf
+    - name: TOSS-04-040700 - Deduplicate values from /etc/postfix/main.cf
       ansible.builtin.lineinfile:
         path: /etc/postfix/main.cf
         create: false
         regexp: ^[ \t]*smtpd_client_restrictions\s*=\s*
         state: absent
       when: dupes.found is defined and dupes.found > 1
-    - name: Insert correct line to /etc/postfix/main.cf
+    - name: TOSS-04-040700 - Insert correct line to /etc/postfix/main.cf
       ansible.builtin.lineinfile:
         path: /etc/postfix/main.cf
         create: true

--- a/ansible/roles/stig/tasks/TOSS_04_040920.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040920.yml
@@ -8,18 +8,18 @@
 
 - name: TOSS-04-040920 - TOSS must restrict privilege elevation to authorized personnel.
   block:
-    - name: Find out if /etc/sudoers.d/* files contain "ALL ALL" permissions
+    - name: TOSS-04-040920 - Find out if /etc/sudoers.d/* files contain "ALL ALL" permissions
       ansible.builtin.find:
         path: /etc/sudoers.d
         patterns: '*'
         contains: 'ALL[[:blank:]]\+ALL'
       register: sudoers_d
-    - name: Remove  occurrences of "ALL ALL" from /etc/sudoers file
+    - name: TOSS-04-040920 - Remove  occurrences of "ALL ALL" from /etc/sudoers file
       ansible.builtin.lineinfile:
         path: /etc/sudoers
         regexp: 'ALL[[:blank:]]\+ALL'
         state: absent
-    - name: Remove found occurrences of "ALL ALL" from /etc/sudoers.d/* files
+    - name: TOSS-04-040920 - Remove found occurrences of "ALL ALL" from /etc/sudoers.d/* files
       ansible.builtin.lineinfile:
         path: '{{ item.path }}'
         regexp: 'ALL[[:blank:]]\+ALL'
@@ -30,7 +30,7 @@
   tags:
     - V-253133
     - SRG-OS-000480-GPOS-00227
-    - SV-253133r825071_rule
+    - SV-253133r826066_rule
     - TOSS-04-040920
     - DISA-STIG-TOSS-04-040920
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040930.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040930.yml
@@ -5,6 +5,22 @@
 # net.ipv4.conf.all.rp_filter = 1 If the returned line does not have a value of
 # "1", or a line is not returned, this is a finding.
 
+# checkid: C-56587r825072_chk
+# checktext: |-
+#   Verify TOSS uses reverse path filtering on all IPv4 interfaces with the following commands:
+#     $ sudo sysctl net.ipv4.conf.all.rp_filter
+#   net.ipv4.conf.all.rp_filter = 1
+#   If the returned line does not have a value of "1", or a line is not returned, this is a finding.
+# description: |-
+#   It is detrimental for operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities or services are often overlooked and therefore may remain unsecured. They increase the risk to the platform by providing additional attack vectors.
+#   Enabling reverse path filtering drops packets with source addresses that are not routable. There is not an equivalent filter for IPv6 traffic.
+# fixid: F-56537r825073_fix
+# fixtext: |-
+#   Configure TOSS to use reverse path filtering on all IPv4 interfaces by adding the following line to a file in the "/etc/sysctl.d" directory:
+#     net.ipv4.conf.all.rp_filter = 1
+#   The system configuration files need to be reloaded for the changes to take effect. To reload the contents of the files, run the following command:
+#     $ sudo sysctl --system
+
 
 - name: TOSS-04-040930 - TOSS must use reverse path filtering on all IPv4 interfaces.
   ansible.posix.sysctl:

--- a/ansible/roles/stig/tasks/TOSS_04_040940.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040940.yml
@@ -1,20 +1,29 @@
 # https://www.stigviewer.com/stig/tri-lab_operating_system_stack_toss_4/2022-08-29/finding/V-253135
 
-# Verify network interfaces are not in promiscuous mode unless approved
-# by the ISSO and documented. Check for the status with the following command: $
-# sudo ip link | grep -i promisc If network interfaces are found on the system in
-# promiscuous mode and their use has not been approved by the ISSO and documented,
-# this is a finding.
+# checkid: C-56588r825075_chk
+# checktext: |-
+#   Verify network interfaces are not in promiscuous mode unless approved by the ISSO and documented.
+#   Check for the status with the following command:
+#     $ sudo ip link | grep -i promisc
+#   If network interfaces are found on the system in promiscuous mode and their use has not been approved by the ISSO and documented, this is a finding.
+# description: |-
+#   Network interfaces in promiscuous mode allow for the capture of all network traffic visible to the system. If unauthorized individuals can access these applications, it may allow them to collect information such as logon IDs, passwords, and key exchanges between systems.
+#   If the system is being used to perform a network troubleshooting function, the use of these tools must be documented with the Information System Security Officer (ISSO) and restricted to only authorized personnel.
+# fixid: F-56538r825076_fix
+# fixtext: |-
+#   Configure network interfaces to turn off promiscuous mode unless approved by the ISSO and documented.
+#   Set the promiscuous mode of an interface to off with the following command:
+#     $ sudo ip link set dev <devicename> multicast off promisc off
 
 
 - name: TOSS-04-040940 - TOSS network interfaces must not be in promiscuous mode.
   block:
-    - name: Gather network interfaces
+    - name: TOSS-04-040940 - Gather network interfaces
       ansible.builtin.command: ip link show
       register: network_interfaces
       changed_when: false
       check_mode: false
-    - name: Disable promiscuous mode
+    - name: TOSS-04-040940 - Disable promiscuous mode
       ansible.builtin.command: ip link set dev {{ item.split(':')[1] }} multicast off promisc off
       loop: '{{ network_interfaces.stdout_lines }}'
       when: 'item.find("PROMISC") != -1'

--- a/ansible/roles/stig/tasks/TOSS_04_040950.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040950.yml
@@ -1,16 +1,29 @@
 # https://www.stigviewer.com/stig/tri-lab_operating_system_stack_toss_4/2022-08-29/finding/V-253136
 
-# Verify the operating system is configured to enable DAC on symlinks
-# with the following commands: Check the status of the fs.protected_symlinks
-# kernel parameter. $ sudo sysctl fs.protected_symlinks fs.protected_symlinks = 1
-# If "fs.protected_symlinks" is not set to "1" or is missing, this is a finding.
-# Check that the configuration files are present to enable this kernel parameter.
-# $ sudo grep -r fs.protected_symlinks /run/sysctl.d/*.conf
-# /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
-# /etc/sysctl.conf /etc/sysctl.d/*.conf
-# /etc/sysctl.d/99-sysctl.conf:fs.protected_symlinks = 1 If
-# "fs.protected_symlinks" is not set to "1", is missing or commented out, this is
-# a finding. If conflicting results are returned, this is a finding.
+# checkid: C-56589r825078_chk
+# checktext: |-
+#   Verify the operating system is configured to enable DAC on symlinks with the following commands:
+#   Check the status of the fs.protected_symlinks kernel parameter.
+#     $ sudo sysctl fs.protected_symlinks
+#       fs.protected_symlinks = 1
+#   If "fs.protected_symlinks" is not set to "1" or is missing, this is a finding.
+#   Check that the configuration files are present to enable this kernel parameter.
+#     $ sudo grep -r fs.protected_symlinks /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf /etc/sysctl.conf /etc/sysctl.d/*.conf
+#       /etc/sysctl.d/99-sysctl.conf:fs.protected_symlinks = 1
+#   If "fs.protected_symlinks" is not set to "1", is missing or commented out, this is a finding.
+#   If conflicting results are returned, this is a finding.
+# description: |-
+#   Discretionary Access Control (DAC) is based on the notion that individual users are "owners" of objects and therefore have discretion over who should be authorized to access the object and in which mode (e.g., read or write). Ownership is usually acquired as a consequence of creating the object or via specified ownership assignment. DAC allows the owner to determine who will have access to objects they control. An example of DAC includes user-controlled file permissions.
+#   When discretionary access control policies are implemented, subjects are not constrained with regard to what actions they can take with information for which they have already been granted access. Thus, subjects that have been granted access to information are not prevented from passing (i.e., the subjects have the discretion to pass) the information to other subjects or objects. A subject that is constrained in its operation by Mandatory Access Control policies is still able to operate under the less rigorous constraints of this requirement. Thus, while Mandatory Access Control imposes constraints preventing a subject from passing information to another subject operating at a different sensitivity level, this requirement permits the subject to pass the information to any subject at the same sensitivity level. The policy is bounded by the information system boundary. Once the information is passed outside the control of the information system, additional means may be required to ensure the constraints remain in effect. While the older, more traditional definitions of discretionary access control require identity-based access control, that limitation is not required for this use of discretionary access control.
+#   By enabling the fs.protected_symlinks kernel parameter, symbolic links are permitted to be followed only when outside a sticky world-writable directory, or when the UID of the link and follower match, or when the directory owner matches the symlink's owner. Disallowing such symlinks helps mitigate vulnerabilities based on insecure file system accessed by privileged programs, avoiding an exploitation vector exploiting unsafe use of open() or creat().
+#   Satisfies: SRG-OS-000312-GPOS-00122, SRG-OS-000324-GPOS-00125
+# fixid: F-56539r825079_fix
+# fixtext: |-
+#   Configure the operating system to enable DAC on symlinks.
+#   Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
+#     fs.protected_symlinks = 1
+#   Load settings from all system configuration files with the following command:
+#     $ sudo sysctl --system
 
 - name: TOSS-04-040950 - TOSS must enable kernel parameters to enforce discretionary access control on symlinks.
   ansible.posix.sysctl:

--- a/ansible/roles/stig/tasks/TOSS_04_040960.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040960.yml
@@ -1,16 +1,29 @@
 # https://www.stigviewer.com/stig/tri-lab_operating_system_stack_toss_4/2022-08-29/finding/V-253137
 
-# Verify the operating system is configured to enable DAC on hardlinks
-# with the following commands: Check the status of the fs.protected_hardlinks
-# kernel parameter. $ sudo sysctl fs.protected_hardlinks fs.protected_hardlinks =
-# 1 If "fs.protected_hardlinks" is not set to "1" or is missing, this is a
-# finding. Check that the configuration files are present to enable this kernel
-# parameter. $ sudo grep -r fs.protected_hardlinks /run/sysctl.d/*.conf
-# /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
-# /etc/sysctl.conf /etc/sysctl.d/*.conf
-# /etc/sysctl.d/99-sysctl.conf:fs.protected_hardlinks = 1 If
-# "fs.protected_hardlinks" is not set to "1", is missing or commented out, this is
-# a finding. If conflicting results are returned, this is a finding.
+#  checkid: C-56590r825081_chk
+#  checktext: |-
+#    Verify the operating system is configured to enable DAC on hardlinks with the following commands:
+#    Check the status of the fs.protected_hardlinks kernel parameter.
+#      $ sudo sysctl fs.protected_hardlinks
+#        fs.protected_hardlinks = 1
+#    If "fs.protected_hardlinks" is not set to "1" or is missing, this is a finding.
+#    Check that the configuration files are present to enable this kernel parameter.
+#      $ sudo grep -r fs.protected_hardlinks /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf /etc/sysctl.conf /etc/sysctl.d/*.conf
+#        /etc/sysctl.d/99-sysctl.conf:fs.protected_hardlinks = 1
+#    If "fs.protected_hardlinks" is not set to "1", is missing or commented out, this is a finding.
+#    If conflicting results are returned, this is a finding.
+#  description: |-
+#    Discretionary Access Control (DAC) is based on the notion that individual users are "owners" of objects and therefore have discretion over who should be authorized to access the object and in which mode (e.g., read or write). Ownership is usually acquired as a consequence of creating the object or via specified ownership assignment. DAC allows the owner to determine who will have access to objects they control. An example of DAC includes user-controlled file permissions.
+#    When discretionary access control policies are implemented, subjects are not constrained with regard to what actions they can take with information for which they have already been granted access. Thus, subjects that have been granted access to information are not prevented from passing (i.e., the subjects have the discretion to pass) the information to other subjects or objects. A subject that is constrained in its operation by Mandatory Access Control policies is still able to operate under the less rigorous constraints of this requirement. Thus, while Mandatory Access Control imposes constraints preventing a subject from passing information to another subject operating at a different sensitivity level, this requirement permits the subject to pass the information to any subject at the same sensitivity level. The policy is bounded by the information system boundary. Once the information is passed outside the control of the information system, additional means may be required to ensure the constraints remain in effect. While the older, more traditional definitions of discretionary access control require identity-based access control, that limitation is not required for this use of discretionary access control.
+#    By enabling the fs.protected_hardlinks kernel parameter, users can no longer create soft or hard links to files they do not own. Disallowing such hardlinks mitigate vulnerabilities based on insecure file system accessed by privileged programs, avoiding an exploitation vector exploiting unsafe use of open() or creat().
+#  Satisfies: SRG-OS-000312-GPOS-00122, SRG-OS-000324-GPOS-00125
+#  fixid: F-56540r825082_fix
+#  fixtext: |-
+#    Configure the operating system to enable DAC on hardlinks.
+#    Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
+#      fs.protected_hardlinks = 1
+#    Load settings from all system configuration files with the following command:
+#      $ sudo sysctl --system
 
 
 - name: TOSS-04-040960 - TOSS must enable kernel parameters to enforce discretionary access control on hardlinks.


### PR DESCRIPTION
Most changes are either adding or correcting the STIG ID in the task names. Other minor corrections are:

- TOSS-04-040690 - added a `rescue` handler because the playbook would stop running if this fails. The `rescue` allows the task to fail, then continue on with running the playbook
- TOSS-04-040920 - corrected SV number under tags
- for 4 files, I edited the comments to make the content more readable. I stopped after those because it was adding a lot of time working on this. I can adjust the rest at a later time.
- TOSS-04-030900 - corrected tasks to match the stig item's ask and allow, if it fails, ensure the ansible run completes. Originally, the playbook would stop running if it fails. Also, `git.ignore` neeeded to include the usage of the `shell` ansible task command in order to pass the linting.