### PR TITLE
Remove rule ID tags

### DIFF
--- a/ansible/roles/stig/tasks/TOSS_04_010000.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010000.yml
@@ -56,7 +56,6 @@
   tags:
     - V-252911
     - SRG-OS-000023-GPOS-00006
-    - SV-252911r824057_rule
     - TOSS-04-010000
     - DISA-STIG-TOSS-04-010000
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010010.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010010.yml
@@ -34,7 +34,6 @@
   tags:
     - V-252912
     - SRG-OS-000066-GPOS-00034
-    - SV-252912r824060_rule
     - TOSS-04-010010
     - DISA-STIG-TOSS-04-010010
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010020.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010020.yml
@@ -40,7 +40,6 @@
   tags:
     - V-252913
     - SRG-OS-000067-GPOS-00035
-    - SV-252913r824063_rule
     - TOSS-04-010020
     - DISA-STIG-TOSS-04-010020
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010030.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010030.yml
@@ -19,7 +19,6 @@
   tags:
     - V-252914
     - SRG-OS-000080-GPOS-00048
-    - SV-252914r824066_rule
     - TOSS-04-010030
     - DISA-STIG-TOSS-04-010030
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010040.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010040.yml
@@ -23,7 +23,6 @@
   tags:
     - V-252915
     - SRG-OS-000109-GPOS-00056
-    - SV-252915r824069_rule
     - TOSS-04-010040
     - DISA-STIG-TOSS-04-010040
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010050.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010050.yml
@@ -21,7 +21,6 @@
   tags:
     - V-252916
     - SRG-OS-000114-GPOS-00059
-    - SV-252916r824072_rule
     - TOSS-04-010050
     - DISA-STIG-TOSS-04-010050
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010060.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010060.yml
@@ -36,7 +36,6 @@
   tags:
     - V-252917
     - SRG-OS-000120-GPOS-00061
-    - SV-252917r824075_rule
     - TOSS-04-010060
     - DISA-STIG-TOSS-04-010060
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010070.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010070.yml
@@ -36,7 +36,6 @@
   tags:
     - V-252918
     - SRG-OS-000120-GPOS-00061
-    - SV-252918r824078_rule
     - TOSS-04-010070
     - DISA-STIG-TOSS-04-010070
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010080.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010080.yml
@@ -63,7 +63,6 @@
   tags:
     - V-252919
     - SRG-OS-000125-GPOS-00065
-    - SV-252919r824081_rule
     - TOSS-04-010080
     - DISA-STIG-TOSS-04-010080
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010090.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010090.yml
@@ -19,6 +19,5 @@
     - medium_severity
     - NASA-ASCS-20280
     - SRG-OS-000134-GPOS-00068
-    - SV-252920r824084_rule
     - TOSS-04-010090
     - V-252920

--- a/ansible/roles/stig/tasks/TOSS_04_010100.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010100.yml
@@ -25,7 +25,6 @@
   tags:
     - V-252921
     - SRG-OS-000138-GPOS-00069
-    - SV-252921r824087_rule
     - TOSS-04-010100
     - DISA-STIG-TOSS-04-010100
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010110.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010110.yml
@@ -21,7 +21,6 @@
   tags:
     - V-252922
     - SRG-OS-000142-GPOS-00071
-    - SV-252922r824090_rule
     - TOSS-04-010110
     - DISA-STIG-TOSS-04-010110
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010120.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010120.yml
@@ -50,7 +50,6 @@
   tags:
     - V-252923
     - SRG-OS-000228-GPOS-00088
-    - SV-252923r824093_rule
     - TOSS-04-010120
     - DISA-STIG-TOSS-04-010120
     - low_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010140.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010140.yml
@@ -62,7 +62,6 @@
   tags:
     - V-252924
     - SRG-OS-000250-GPOS-00093
-    - SV-252924r824096_rule
     - TOSS-04-010140
     - DISA-STIG-TOSS-04-010140
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010150.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010150.yml
@@ -19,7 +19,6 @@
   tags:
     - V-252925
     - SRG-OS-000250-GPOS-00093
-    - SV-252925r824099_rule
     - TOSS-04-010150
     - DISA-STIG-TOSS-04-010150
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010160.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010160.yml
@@ -33,7 +33,6 @@
   tags:
     - V-252926
     - SRG-OS-000250-GPOS-00093
-    - SV-252926r824102_rule
     - TOSS-04-010160
     - DISA-STIG-TOSS-04-010160
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010170.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010170.yml
@@ -19,7 +19,6 @@
   tags:
     - V-252927
     - SRG-OS-000269-GPOS-00103
-    - SV-252927r824105_rule
     - TOSS-04-010170
     - DISA-STIG-TOSS-04-010170
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010180.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010180.yml
@@ -53,7 +53,6 @@
   tags:
     - V-252928
     - SRG-OS-000355-GPOS-00143
-    - SV-252928r825085_rule
     - TOSS-04-010180
     - DISA-STIG-TOSS-04-010180
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010210.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010210.yml
@@ -32,7 +32,6 @@
   tags:
     - V-252929
     - SRG-OS-000363-GPOS-00150
-    - SV-252929r824111_rule
     - TOSS-04-010210
     - DISA-STIG-TOSS-04-010210
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010220.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010220.yml
@@ -38,7 +38,6 @@
   tags:
     - V-252930
     - SRG-OS-000366-GPOS-00153
-    - SV-252930r824114_rule
     - TOSS-04-010220
     - DISA-STIG-TOSS-04-010220
     - high_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010230.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010230.yml
@@ -39,7 +39,6 @@
   tags:
     - V-252931
     - SRG-OS-000373-GPOS-00158
-    - SV-252931r824117_rule
     - TOSS-04-010230
     - DISA-STIG-TOSS-04-010230
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010240.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010240.yml
@@ -18,7 +18,6 @@
   tags:
     - V-252932
     - SRG-OS-000375-GPOS-00160
-    - SV-252932r824120_rule
     - TOSS-04-010240
     - DISA-STIG-TOSS-04-010240
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010250.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010250.yml
@@ -35,7 +35,6 @@
   tags:
     - V-252933
     - SRG-OS-000383-GPOS-00166
-    - SV-252933r824123_rule
     - TOSS-04-010250
     - DISA-STIG-TOSS-04-010250
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010280.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010280.yml
@@ -24,7 +24,6 @@
   tags:
     - V-252934
     - SRG-OS-000423-GPOS-00187
-    - SV-252934r824126_rule
     - TOSS-04-010280
     - DISA-STIG-TOSS-04-010280
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010330.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010330.yml
@@ -54,7 +54,6 @@
   tags:
     - V-252935
     - SRG-OS-000480-GPOS-00227
-    - SV-252935r824129_rule
     - TOSS-04-010330
     - DISA-STIG-TOSS-04-010330
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010340.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010340.yml
@@ -18,7 +18,6 @@
   tags:
     - V-252936
     - SRG-OS-000480-GPOS-00227
-    - SV-252936r824132_rule
     - TOSS-04-010340
     - DISA-STIG-TOSS-04-010340
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010350.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010350.yml
@@ -26,7 +26,6 @@
   tags:
     - V-252937
     - SRG-OS-000480-GPOS-00227
-    - SV-252937r824135_rule
     - TOSS-04-010350
     - DISA-STIG-TOSS-04-010350
     - high_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010360.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010360.yml
@@ -19,7 +19,6 @@
   tags:
     - V-252938
     - SRG-OS-000480-GPOS-00227
-    - SV-252938r824138_rule
     - TOSS-04-010360
     - DISA-STIG-TOSS-04-010360
     - high_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010370.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010370.yml
@@ -29,7 +29,6 @@
   tags:
     - V-252939
     - SRG-OS-000480-GPOS-00227
-    - SV-252939r824141_rule
     - TOSS-04-010370
     - DISA-STIG-TOSS-04-010370
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010380.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010380.yml
@@ -15,7 +15,6 @@
   tags:
     - V-252940
     - SRG-OS-000480-GPOS-00227
-    - SV-252940r824144_rule
     - TOSS-04-010380
     - DISA-STIG-TOSS-04-010380
     - high_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010390.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010390.yml
@@ -34,7 +34,6 @@
   tags:
     - V-252941
     - SRG-OS-000480-GPOS-00227
-    - SV-252941r824147_rule
     - TOSS-04-010390
     - DISA-STIG-TOSS-04-010390
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010400.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010400.yml
@@ -22,7 +22,6 @@
   tags:
     - V-252942
     - SRG-OS-000480-GPOS-00227
-    - SV-252942r824150_rule
     - TOSS-04-010400
     - DISA-STIG-TOSS-04-010400
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010410.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010410.yml
@@ -19,7 +19,6 @@
   tags:
     - V-252943
     - SRG-OS-000480-GPOS-00227
-    - SV-252943r824153_rule
     - TOSS-04-010410
     - DISA-STIG-TOSS-04-010410
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010420.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010420.yml
@@ -21,7 +21,6 @@
   tags:
     - V-252944
     - SRG-OS-000480-GPOS-00227
-    - SV-252944r824156_rule
     - TOSS-04-010420
     - DISA-STIG-TOSS-04-010420
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_010430.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_010430.yml
@@ -25,7 +25,6 @@
   tags:
     - V-252945
     - SRG-OS-000480-GPOS-00229
-    - SV-252945r824159_rule
     - TOSS-04-010430
     - DISA-STIG-TOSS-04-010430
     - high_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020000.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020000.yml
@@ -31,7 +31,6 @@
   tags:
     - V-252946
     - SRG-OS-000021-GPOS-00005
-    - SV-252946r824162_rule
     - TOSS-04-020000
     - DISA-STIG-TOSS-04-020000
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020010.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020010.yml
@@ -25,7 +25,6 @@
   tags:
     - V-252947
     - SRG-OS-000027-GPOS-00008
-    - SV-252947r824165_rule
     - TOSS-04-020010
     - DISA-STIG-TOSS-04-020010
     - low_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020020.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020020.yml
@@ -33,7 +33,6 @@
   tags:
     - V-252948
     - SRG-OS-000028-GPOS-00009
-    - SV-252948r824168_rule
     - TOSS-04-020020
     - DISA-STIG-TOSS-04-020020
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020030.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020030.yml
@@ -29,7 +29,6 @@
   tags:
     - V-252949
     - SRG-OS-000029-GPOS-00010
-    - SV-252949r824171_rule
     - TOSS-04-020030
     - DISA-STIG-TOSS-04-020030
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020050.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020050.yml
@@ -31,7 +31,6 @@
   tags:
     - V-252950
     - SRG-OS-000068-GPOS-00036
-    - SV-252950r824174_rule
     - TOSS-04-020050
     - DISA-STIG-TOSS-04-020050
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020060.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020060.yml
@@ -31,7 +31,6 @@
   tags:
     - V-252951
     - SRG-OS-000104-GPOS-00051
-    - SV-252951r824177_rule
     - TOSS-04-020060
     - DISA-STIG-TOSS-04-020060
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020070.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020070.yml
@@ -102,7 +102,6 @@
   tags:
     - V-252952
     - SRG-OS-000105-GPOS-00052
-    - SV-252952r824180_rule
     - TOSS-04-020070
     - DISA-STIG-TOSS-04-020070
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020120.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020120.yml
@@ -17,7 +17,6 @@
   tags:
     - V-252953
     - SRG-OS-000118-GPOS-00060
-    - SV-252953r824183_rule
     - TOSS-04-020120
     - DISA-STIG-TOSS-04-020120
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020140.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020140.yml
@@ -33,7 +33,6 @@
   tags:
     - V-252954
     - SRG-OS-000123-GPOS-00064
-    - SV-252954r824186_rule
     - TOSS-04-020140
     - DISA-STIG-TOSS-04-020140
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020150.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020150.yml
@@ -21,7 +21,6 @@
   tags:
     - V-252955
     - SRG-OS-000206-GPOS-00084
-    - SV-252955r824189_rule
     - TOSS-04-020150
     - DISA-STIG-TOSS-04-020150
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020160.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020160.yml
@@ -26,7 +26,6 @@
   tags:
     - V-252956
     - SRG-OS-000299-GPOS-00117
-    - SV-252956r824192_rule
     - TOSS-04-020160
     - DISA-STIG-TOSS-04-020160
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020170.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020170.yml
@@ -36,7 +36,6 @@
   tags:
     - V-252957
     - SRG-OS-000329-GPOS-00128
-    - SV-252957r824195_rule
     - TOSS-04-020170
     - DISA-STIG-TOSS-04-020170
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020180.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020180.yml
@@ -27,7 +27,6 @@
   tags:
     - V-252958
     - SRG-OS-000373-GPOS-00156
-    - SV-252958r824198_rule
     - TOSS-04-020180
     - DISA-STIG-TOSS-04-020180
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020190.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020190.yml
@@ -29,7 +29,6 @@
   tags:
     - V-252959
     - SRG-OS-000373-GPOS-00157
-    - SV-252959r824201_rule
     - TOSS-04-020190
     - DISA-STIG-TOSS-04-020190
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020200.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020200.yml
@@ -16,7 +16,6 @@
   tags:
     - V-252960
     - SRG-OS-000480-GPOS-00227
-    - SV-252960r824204_rule
     - TOSS-04-020200
     - DISA-STIG-TOSS-04-020200
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020210.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020210.yml
@@ -35,7 +35,6 @@
   tags:
     - V-252961
     - SRG-OS-000480-GPOS-00227
-    - SV-252961r824207_rule
     - TOSS-04-020210
     - DISA-STIG-TOSS-04-020210
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020230.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020230.yml
@@ -43,7 +43,6 @@
   tags:
     - V-252962
     - SRG-OS-000480-GPOS-00227
-    - SV-252962r824210_rule
     - TOSS-04-020230
     - DISA-STIG-TOSS-04-020230
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020240.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020240.yml
@@ -29,7 +29,6 @@
   tags:
     - V-252963
     - SRG-OS-000480-GPOS-00227
-    - SV-252963r824213_rule
     - TOSS-04-020240
     - DISA-STIG-TOSS-04-020240
     - high_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020250.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020250.yml
@@ -28,7 +28,6 @@
   tags:
     - V-252964
     - SRG-OS-000480-GPOS-00227
-    - SV-252964r824216_rule
     - TOSS-04-020250
     - DISA-STIG-TOSS-04-020250
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020260.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020260.yml
@@ -39,7 +39,6 @@
   tags:
     - V-252965
     - SRG-OS-000480-GPOS-00227
-    - SV-252965r824219_rule
     - TOSS-04-020260
     - DISA-STIG-TOSS-04-020260
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020270.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020270.yml
@@ -20,7 +20,6 @@
   tags:
     - V-252966
     - SRG-OS-000480-GPOS-00227
-    - SV-252966r824222_rule
     - TOSS-04-020270
     - DISA-STIG-TOSS-04-020270
     - high_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020280.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020280.yml
@@ -33,7 +33,6 @@
   tags:
     - V-252967
     - SRG-OS-000480-GPOS-00227
-    - SV-252967r824225_rule
     - TOSS-04-020280
     - DISA-STIG-TOSS-04-020280
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020290.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020290.yml
@@ -18,7 +18,6 @@
   tags:
     - V-252968
     - SRG-OS-000480-GPOS-00228
-    - SV-252968r824228_rule
     - TOSS-04-020290
     - DISA-STIG-TOSS-04-020290
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020300.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020300.yml
@@ -29,7 +29,6 @@
   tags:
     - V-252969
     - SRG-OS-000480-GPOS-00230
-    - SV-252969r824231_rule
     - TOSS-04-020300
     - DISA-STIG-TOSS-04-020300
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020310.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020310.yml
@@ -25,7 +25,6 @@
   tags:
     - V-252970
     - SRG-OS-000480-GPOS-00230
-    - SV-252970r824234_rule
     - TOSS-04-020310
     - DISA-STIG-TOSS-04-020310
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_020320.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_020320.yml
@@ -31,7 +31,6 @@
   tags:
     - V-252971
     - SRG-OS-000480-GPOS-00230
-    - SV-252971r824237_rule
     - TOSS-04-020320
     - DISA-STIG-TOSS-04-020320
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030000.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030000.yml
@@ -19,7 +19,6 @@
   tags:
     - V-252972
     - SRG-OS-000004-GPOS-00004
-    - SV-252972r824240_rule
     - TOSS-04-030000
     - DISA-STIG-TOSS-04-030000
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030010.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030010.yml
@@ -24,7 +24,6 @@
   tags:
     - V-252973
     - SRG-OS-000037-GPOS-00015
-    - SV-252973r824243_rule
     - TOSS-04-030010
     - DISA-STIG-TOSS-04-030010
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030060.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030060.yml
@@ -18,7 +18,6 @@
   tags:
     - V-252974
     - SRG-OS-000042-GPOS-00020
-    - SV-252974r824246_rule
     - TOSS-04-030060
     - DISA-STIG-TOSS-04-030060
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030080.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030080.yml
@@ -21,7 +21,6 @@
   tags:
     - V-252975
     - SRG-OS-000046-GPOS-00022
-    - SV-252975r824249_rule
     - TOSS-04-030080
     - DISA-STIG-TOSS-04-030080
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030090.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030090.yml
@@ -19,7 +19,6 @@
   tags:
     - V-252976
     - SRG-OS-000047-GPOS-00023
-    - SV-252976r824252_rule
     - TOSS-04-030090
     - DISA-STIG-TOSS-04-030090
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030120.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030120.yml
@@ -20,7 +20,6 @@
   tags:
     - V-252977
     - SRG-OS-000057-GPOS-00027
-    - SV-252977r824255_rule
     - TOSS-04-030120
     - DISA-STIG-TOSS-04-030120
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030130.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030130.yml
@@ -20,7 +20,6 @@
   tags:
     - V-252978
     - SRG-OS-000057-GPOS-00027
-    - SV-252978r824258_rule
     - TOSS-04-030130
     - DISA-STIG-TOSS-04-030130
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030140.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030140.yml
@@ -20,7 +20,6 @@
   tags:
     - V-252979
     - SRG-OS-000057-GPOS-00027
-    - SV-252979r824261_rule
     - TOSS-04-030140
     - DISA-STIG-TOSS-04-030140
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030150.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030150.yml
@@ -20,7 +20,6 @@
   tags:
     - V-252980
     - SRG-OS-000057-GPOS-00027
-    - SV-252980r824264_rule
     - TOSS-04-030150
     - DISA-STIG-TOSS-04-030150
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030160.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030160.yml
@@ -20,7 +20,6 @@
   tags:
     - V-252981
     - SRG-OS-000057-GPOS-00027
-    - SV-252981r824267_rule
     - TOSS-04-030160
     - DISA-STIG-TOSS-04-030160
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030170.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030170.yml
@@ -21,7 +21,6 @@
   tags:
     - V-252982
     - SRG-OS-000057-GPOS-00027
-    - SV-252982r824270_rule
     - TOSS-04-030170
     - DISA-STIG-TOSS-04-030170
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030180.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030180.yml
@@ -19,7 +19,6 @@
   tags:
     - V-252983
     - SRG-OS-000057-GPOS-00027
-    - SV-252983r824273_rule
     - TOSS-04-030180
     - DISA-STIG-TOSS-04-030180
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030190.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030190.yml
@@ -18,7 +18,6 @@
   tags:
     - V-252984
     - SRG-OS-000057-GPOS-00027
-    - SV-252984r824276_rule
     - TOSS-04-030190
     - DISA-STIG-TOSS-04-030190
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030310.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030310.yml
@@ -18,7 +18,6 @@
   tags:
     - V-252985
     - SRG-OS-000037-GPOS-00015
-    - SV-252985r824279_rule
     - TOSS-04-030310
     - DISA-STIG-TOSS-04-030310
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030320.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030320.yml
@@ -18,7 +18,6 @@
   tags:
     - V-252986
     - SRG-OS-000037-GPOS-00015
-    - SV-252986r824282_rule
     - TOSS-04-030320
     - DISA-STIG-TOSS-04-030320
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030330.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030330.yml
@@ -19,7 +19,6 @@
   tags:
     - V-252987
     - SRG-OS-000037-GPOS-00015
-    - SV-252987r824285_rule
     - TOSS-04-030330
     - DISA-STIG-TOSS-04-030330
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030340.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030340.yml
@@ -18,7 +18,6 @@
   tags:
     - V-252988
     - SRG-OS-000037-GPOS-00015
-    - SV-252988r824288_rule
     - TOSS-04-030340
     - DISA-STIG-TOSS-04-030340
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030350.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030350.yml
@@ -19,7 +19,6 @@
   tags:
     - V-252989
     - SRG-OS-000037-GPOS-00015
-    - SV-252989r824291_rule
     - TOSS-04-030350
     - DISA-STIG-TOSS-04-030350
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030360.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030360.yml
@@ -19,7 +19,6 @@
   tags:
     - V-252990
     - SRG-OS-000037-GPOS-00015
-    - SV-252990r824294_rule
     - TOSS-04-030360
     - DISA-STIG-TOSS-04-030360
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030370.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030370.yml
@@ -19,7 +19,6 @@
   tags:
     - V-252991
     - SRG-OS-000037-GPOS-00015
-    - SV-252991r824297_rule
     - TOSS-04-030370
     - DISA-STIG-TOSS-04-030370
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030380.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030380.yml
@@ -19,7 +19,6 @@
   tags:
     - V-252992
     - SRG-OS-000037-GPOS-00015
-    - SV-252992r824300_rule
     - TOSS-04-030380
     - DISA-STIG-TOSS-04-030380
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030390.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030390.yml
@@ -18,7 +18,6 @@
   tags:
     - V-252993
     - SRG-OS-000037-GPOS-00015
-    - SV-252993r824303_rule
     - TOSS-04-030390
     - DISA-STIG-TOSS-04-030390
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030400.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030400.yml
@@ -19,7 +19,6 @@
   tags:
     - V-252994
     - SRG-OS-000037-GPOS-00015
-    - SV-252994r824306_rule
     - TOSS-04-030400
     - DISA-STIG-TOSS-04-030400
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030410.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030410.yml
@@ -18,7 +18,6 @@
   tags:
     - V-252995
     - SRG-OS-000037-GPOS-00015
-    - SV-252995r824309_rule
     - TOSS-04-030410
     - DISA-STIG-TOSS-04-030410
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030420.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030420.yml
@@ -26,7 +26,6 @@
   tags:
     - V-252996
     - SRG-OS-000037-GPOS-00015
-    - SV-252996r824312_rule
     - TOSS-04-030420
     - DISA-STIG-TOSS-04-030420
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030430.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030430.yml
@@ -26,7 +26,6 @@
   tags:
     - V-252997
     - SRG-OS-000037-GPOS-00015
-    - SV-252997r824315_rule
     - TOSS-04-030430
     - DISA-STIG-TOSS-04-030430
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030440.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030440.yml
@@ -26,7 +26,6 @@
   tags:
     - V-252998
     - SRG-OS-000037-GPOS-00015
-    - SV-252998r824318_rule
     - TOSS-04-030440
     - DISA-STIG-TOSS-04-030440
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030450.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030450.yml
@@ -26,7 +26,6 @@
   tags:
     - V-252999
     - SRG-OS-000037-GPOS-00015
-    - SV-252999r824321_rule
     - TOSS-04-030450
     - DISA-STIG-TOSS-04-030450
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030460.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030460.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253000
     - SRG-OS-000037-GPOS-00015
-    - SV-253000r824324_rule
     - TOSS-04-030460
     - DISA-STIG-TOSS-04-030460
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030470.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030470.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253001
     - SRG-OS-000037-GPOS-00015
-    - SV-253001r824327_rule
     - TOSS-04-030470
     - DISA-STIG-TOSS-04-030470
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030480.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030480.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253002
     - SRG-OS-000037-GPOS-00015
-    - SV-253002r824330_rule
     - TOSS-04-030480
     - DISA-STIG-TOSS-04-030480
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030490.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030490.yml
@@ -27,7 +27,6 @@
   tags:
     - V-253003
     - SRG-OS-000037-GPOS-00015
-    - SV-253003r824333_rule
     - TOSS-04-030490
     - DISA-STIG-TOSS-04-030490
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030500.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030500.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253004
     - SRG-OS-000037-GPOS-00015
-    - SV-253004r824336_rule
     - TOSS-04-030500
     - DISA-STIG-TOSS-04-030500
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030510.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030510.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253005
     - SRG-OS-000037-GPOS-00015
-    - SV-253005r824339_rule
     - TOSS-04-030510
     - DISA-STIG-TOSS-04-030510
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030520.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030520.yml
@@ -19,7 +19,6 @@
   tags:
     - V-253006
     - SRG-OS-000037-GPOS-00015
-    - SV-253006r824342_rule
     - TOSS-04-030520
     - DISA-STIG-TOSS-04-030520
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030540.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030540.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253007
     - SRG-OS-000037-GPOS-00015
-    - SV-253007r824345_rule
     - TOSS-04-030540
     - DISA-STIG-TOSS-04-030540
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030550.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030550.yml
@@ -31,6 +31,5 @@
     - medium_severity
     - NASA-ASCS-20009
     - SRG-OS-000063-GPOS-00032
-    - SV-253008r824348_rule
     - TOSS-04-030550
     - V-253008

--- a/ansible/roles/stig/tasks/TOSS_04_030560.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030560.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253009
     - SRG-OS-000064-GPOS-00033
-    - SV-253009r824351_rule
     - TOSS-04-030560
     - DISA-STIG-TOSS-04-030560
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030570.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030570.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253010
     - SRG-OS-000064-GPOS-00033
-    - SV-253010r824354_rule
     - TOSS-04-030570
     - DISA-STIG-TOSS-04-030570
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030580.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030580.yml
@@ -39,7 +39,6 @@
   tags:
     - V-253011
     - SRG-OS-000064-GPOS-00033
-    - SV-253011r824357_rule
     - TOSS-04-030580
     - DISA-STIG-TOSS-04-030580
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030590.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030590.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253012
     - SRG-OS-000064-GPOS-00033
-    - SV-253012r824360_rule
     - TOSS-04-030590
     - DISA-STIG-TOSS-04-030590
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030600.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030600.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253013
     - SRG-OS-000064-GPOS-00033
-    - SV-253013r824363_rule
     - TOSS-04-030600
     - DISA-STIG-TOSS-04-030600
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030610.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030610.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253014
     - SRG-OS-000064-GPOS-00033
-    - SV-253014r824366_rule
     - TOSS-04-030610
     - DISA-STIG-TOSS-04-030610
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030620.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030620.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253015
     - SRG-OS-000064-GPOS-00033
-    - SV-253015r824369_rule
     - TOSS-04-030620
     - DISA-STIG-TOSS-04-030620
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030630.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030630.yml
@@ -40,7 +40,6 @@
   tags:
     - V-253016
     - SRG-OS-000064-GPOS-00033
-    - SV-253016r824372_rule
     - TOSS-04-030630
     - DISA-STIG-TOSS-04-030630
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030640.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030640.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253017
     - SRG-OS-000064-GPOS-00033
-    - SV-253017r824375_rule
     - TOSS-04-030640
     - DISA-STIG-TOSS-04-030640
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030650.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030650.yml
@@ -39,7 +39,6 @@
   tags:
     - V-253018
     - SRG-OS-000064-GPOS-00033
-    - SV-253018r824378_rule
     - TOSS-04-030650
     - DISA-STIG-TOSS-04-030650
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030660.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030660.yml
@@ -40,7 +40,6 @@
   tags:
     - V-253019
     - SRG-OS-000064-GPOS-00033
-    - SV-253019r824381_rule
     - TOSS-04-030660
     - DISA-STIG-TOSS-04-030660
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030670.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030670.yml
@@ -39,7 +39,6 @@
   tags:
     - V-253020
     - SRG-OS-000064-GPOS-00033
-    - SV-253020r824384_rule
     - TOSS-04-030670
     - DISA-STIG-TOSS-04-030670
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030680.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030680.yml
@@ -40,7 +40,6 @@
   tags:
     - V-253021
     - SRG-OS-000064-GPOS-00033
-    - SV-253021r824387_rule
     - TOSS-04-030680
     - DISA-STIG-TOSS-04-030680
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030750.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030750.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253022
     - SRG-OS-000256-GPOS-00097
-    - SV-253022r824738_rule
     - TOSS-04-030750
     - DISA-STIG-TOSS-04-030750
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030780.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030780.yml
@@ -33,7 +33,6 @@
   tags:
     - V-253023
     - SRG-OS-000278-GPOS-00108
-    - SV-253023r824741_rule
     - TOSS-04-030780
     - DISA-STIG-TOSS-04-030780
     - medium_severity
@@ -50,7 +49,6 @@
   tags:
     - V-253023
     - SRG-OS-000278-GPOS-00108
-    - SV-253023r824741_rule
     - TOSS-04-030780
     - DISA-STIG-TOSS-04-030780
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030790.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030790.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253024
     - SRG-OS-000303-GPOS-00120
-    - SV-253024r824744_rule
     - TOSS-04-030790
     - DISA-STIG-TOSS-04-030790
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030800.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030800.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253025
     - SRG-OS-000303-GPOS-00120
-    - SV-253025r824747_rule
     - TOSS-04-030800
     - DISA-STIG-TOSS-04-030800
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030810.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030810.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253026
     - SRG-OS-000303-GPOS-00120
-    - SV-253026r824750_rule
     - TOSS-04-030810
     - DISA-STIG-TOSS-04-030810
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030820.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030820.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253027
     - SRG-OS-000303-GPOS-00120
-    - SV-253027r824753_rule
     - TOSS-04-030820
     - DISA-STIG-TOSS-04-030820
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030840.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030840.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253028
     - SRG-OS-000303-GPOS-00120
-    - SV-253028r824756_rule
     - TOSS-04-030840
     - DISA-STIG-TOSS-04-030840
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030850.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030850.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253029
     - SRG-OS-000303-GPOS-00120
-    - SV-253029r824759_rule
     - TOSS-04-030850
     - DISA-STIG-TOSS-04-030850
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030860.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030860.yml
@@ -38,7 +38,6 @@
   tags:
     - V-253030
     - SRG-OS-000326-GPOS-00126
-    - SV-253030r824762_rule
     - TOSS-04-030860
     - DISA-STIG-TOSS-04-030860
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030890.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030890.yml
@@ -53,7 +53,6 @@
   tags:
     - V-253031
     - SRG-OS-000341-GPOS-00132
-    - SV-253031r824765_rule
     - TOSS-04-030890
     - DISA-STIG-TOSS-04-030890
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030900.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030900.yml
@@ -28,7 +28,6 @@
   tags:
     - V-253032
     - SRG-OS-000342-GPOS-00133
-    - SV-253032r824768_rule
     - TOSS-04-030900
     - DISA-STIG-TOSS-04-030900
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030910.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030910.yml
@@ -38,7 +38,6 @@
   tags:
     - V-253033
     - SRG-OS-000342-GPOS-00133
-    - SV-253033r824771_rule
     - TOSS-04-030910
     - DISA-STIG-TOSS-04-030910
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_030990.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030990.yml
@@ -37,7 +37,6 @@
   tags:
     - V-253034
     - SRG-OS-000458-GPOS-00203
-    - SV-253034r824774_rule
     - TOSS-04-030990
     - DISA-STIG-TOSS-04-030990
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031000.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031000.yml
@@ -37,7 +37,6 @@
   tags:
     - V-253035
     - SRG-OS-000458-GPOS-00203
-    - SV-253035r824777_rule
     - TOSS-04-031000
     - DISA-STIG-TOSS-04-031000
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031100.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031100.yml
@@ -37,7 +37,6 @@
   tags:
     - V-253036
     - SRG-OS-000468-GPOS-00212
-    - SV-253036r824780_rule
     - TOSS-04-031100
     - DISA-STIG-TOSS-04-031100
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031110.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031110.yml
@@ -37,7 +37,6 @@
   tags:
     - V-253037
     - SRG-OS-000468-GPOS-00212
-    - SV-253037r824783_rule
     - TOSS-04-031110
     - DISA-STIG-TOSS-04-031110
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031120.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031120.yml
@@ -37,7 +37,6 @@
   tags:
     - V-253038
     - SRG-OS-000468-GPOS-00212
-    - SV-253038r824786_rule
     - TOSS-04-031120
     - DISA-STIG-TOSS-04-031120
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031130.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031130.yml
@@ -17,7 +17,6 @@
   tags:
     - V-253039
     - SRG-OS-000470-GPOS-00214
-    - SV-253039r824789_rule
     - TOSS-04-031130
     - DISA-STIG-TOSS-04-031130
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031140.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031140.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253040
     - SRG-OS-000471-GPOS-00215
-    - SV-253040r824792_rule
     - TOSS-04-031140
     - DISA-STIG-TOSS-04-031140
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031150.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031150.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253041
     - SRG-OS-000471-GPOS-00215
-    - SV-253041r824795_rule
     - TOSS-04-031150
     - DISA-STIG-TOSS-04-031150
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031160.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031160.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253042
     - SRG-OS-000471-GPOS-00215
-    - SV-253042r824798_rule
     - TOSS-04-031160
     - DISA-STIG-TOSS-04-031160
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031170.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031170.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253043
     - SRG-OS-000471-GPOS-00215
-    - SV-253043r824801_rule
     - TOSS-04-031170
     - DISA-STIG-TOSS-04-031170
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031180.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031180.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253044
     - SRG-OS-000471-GPOS-00215
-    - SV-253044r824804_rule
     - TOSS-04-031180
     - DISA-STIG-TOSS-04-031180
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031190.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031190.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253045
     - SRG-OS-000471-GPOS-00215
-    - SV-253045r824807_rule
     - TOSS-04-031190
     - DISA-STIG-TOSS-04-031190
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031200.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031200.yml
@@ -19,7 +19,6 @@
   tags:
     - V-253046
     - SRG-OS-000471-GPOS-00215
-    - SV-253046r824810_rule
     - TOSS-04-031200
     - DISA-STIG-TOSS-04-031200
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031210.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031210.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253047
     - SRG-OS-000471-GPOS-00215
-    - SV-253047r824813_rule
     - TOSS-04-031210
     - DISA-STIG-TOSS-04-031210
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031220.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031220.yml
@@ -19,7 +19,6 @@
   tags:
     - V-253048
     - SRG-OS-000471-GPOS-00215
-    - SV-253048r824816_rule
     - TOSS-04-031220
     - DISA-STIG-TOSS-04-031220
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031230.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031230.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253049
     - SRG-OS-000471-GPOS-00215
-    - SV-253049r824819_rule
     - TOSS-04-031230
     - DISA-STIG-TOSS-04-031230
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031240.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031240.yml
@@ -17,7 +17,6 @@
   tags:
     - V-253050
     - SRG-OS-000471-GPOS-00216
-    - SV-253050r824822_rule
     - TOSS-04-031240
     - DISA-STIG-TOSS-04-031240
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031340.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031340.yml
@@ -15,7 +15,6 @@
   tags:
     - V-253051
     - SRG-OS-000480-GPOS-00227
-    - SV-253051r824825_rule
     - TOSS-04-031340
     - DISA-STIG-TOSS-04-031340
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031350.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031350.yml
@@ -19,7 +19,6 @@
   tags:
     - V-253052
     - SRG-OS-000480-GPOS-00227
-    - SV-253052r824828_rule
     - TOSS-04-031350
     - DISA-STIG-TOSS-04-031350
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031360.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031360.yml
@@ -19,7 +19,6 @@
   tags:
     - V-253053
     - SRG-OS-000480-GPOS-00227
-    - SV-253053r824831_rule
     - TOSS-04-031360
     - DISA-STIG-TOSS-04-031360
     - low_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031370.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031370.yml
@@ -17,7 +17,6 @@
   tags:
     - V-253054
     - SRG-OS-000480-GPOS-00227
-    - SV-253054r824834_rule
     - TOSS-04-031370
     - DISA-STIG-TOSS-04-031370
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_031380.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_031380.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253055
     - SRG-OS-000480-GPOS-00227
-    - SV-253055r824837_rule
     - TOSS-04-031380
     - DISA-STIG-TOSS-04-031380
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040010.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040010.yml
@@ -60,7 +60,6 @@
   tags:
     - V-253056
     - SRG-OS-000032-GPOS-00013
-    - SV-253056r824840_rule
     - TOSS-04-040010
     - DISA-STIG-TOSS-04-040010
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040020.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040020.yml
@@ -40,7 +40,6 @@
   tags:
     - V-253057
     - SRG-OS-000033-GPOS-00014
-    - SV-253057r824843_rule
     - TOSS-04-040020
     - DISA-STIG-TOSS-04-040020
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040030.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040030.yml
@@ -40,7 +40,6 @@
   tags:
     - V-253058
     - SRG-OS-000033-GPOS-00014
-    - SV-253058r824846_rule
     - TOSS-04-040030
     - DISA-STIG-TOSS-04-040030
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040040.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040040.yml
@@ -53,7 +53,6 @@
   tags:
     - V-253059
     - SRG-OS-000033-GPOS-00014
-    - SV-253059r825086_rule
     - TOSS-04-040040
     - DISA-STIG-TOSS-04-040040
     - high_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040050.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040050.yml
@@ -17,7 +17,6 @@
   tags:
     - V-253060
     - SRG-OS-000069-GPOS-00037
-    - SV-253060r824852_rule
     - TOSS-04-040050
     - DISA-STIG-TOSS-04-040050
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040060.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040060.yml
@@ -17,7 +17,6 @@
   tags:
     - V-253061
     - SRG-OS-000070-GPOS-00038
-    - SV-253061r824855_rule
     - TOSS-04-040060
     - DISA-STIG-TOSS-04-040060
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040070.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040070.yml
@@ -17,7 +17,6 @@
   tags:
     - V-253062
     - SRG-OS-000071-GPOS-00039
-    - SV-253062r824858_rule
     - TOSS-04-040070
     - DISA-STIG-TOSS-04-040070
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040080.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040080.yml
@@ -17,7 +17,6 @@
   tags:
     - V-253063
     - SRG-OS-000072-GPOS-00040
-    - SV-253063r824861_rule
     - TOSS-04-040080
     - DISA-STIG-TOSS-04-040080
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040090.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040090.yml
@@ -16,7 +16,6 @@
   tags:
     - V-253064
     - SRG-OS-000073-GPOS-00041
-    - SV-253064r824864_rule
     - TOSS-04-040090
     - DISA-STIG-TOSS-04-040090
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040100.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040100.yml
@@ -14,7 +14,6 @@
   tags:
     - V-253065
     - SRG-OS-000074-GPOS-00042
-    - SV-253065r824867_rule
     - TOSS-04-040100
     - DISA-STIG-TOSS-04-040100
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040110.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040110.yml
@@ -16,7 +16,6 @@
   tags:
     - V-253066
     - SRG-OS-000075-GPOS-00043
-    - SV-253066r824870_rule
     - TOSS-04-040110
     - DISA-STIG-TOSS-04-040110
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040120.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040120.yml
@@ -15,7 +15,6 @@
   tags:
     - V-253067
     - SRG-OS-000076-GPOS-00044
-    - SV-253067r824873_rule
     - TOSS-04-040120
     - DISA-STIG-TOSS-04-040120
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040130.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040130.yml
@@ -25,7 +25,6 @@
   tags:
     - V-253068
     - SRG-OS-000077-GPOS-00045
-    - SV-253068r824876_rule
     - TOSS-04-040130
     - DISA-STIG-TOSS-04-040130
     - medium_severity
@@ -44,7 +43,6 @@
   tags:
     - V-253068
     - SRG-OS-000077-GPOS-00045
-    - SV-253068r824876_rule
     - TOSS-04-040130
     - DISA-STIG-TOSS-04-040130
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040140.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040140.yml
@@ -19,7 +19,6 @@
   tags:
     - V-253069
     - SRG-OS-000078-GPOS-00046
-    - SV-253069r824879_rule
     - TOSS-04-040140
     - DISA-STIG-TOSS-04-040140
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040150.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040150.yml
@@ -54,7 +54,6 @@
   tags:
     - V-253070
     - SRG-OS-000095-GPOS-00049
-    - SV-253070r824882_rule
     - TOSS-04-040150
     - DISA-STIG-TOSS-04-040150
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040160.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040160.yml
@@ -36,7 +36,6 @@
   tags:
     - V-253071
     - SRG-OS-000095-GPOS-00049
-    - SV-253071r824885_rule
     - TOSS-04-040160
     - DISA-STIG-TOSS-04-040160
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040170.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040170.yml
@@ -35,7 +35,6 @@
   tags:
     - V-253072
     - SRG-OS-000095-GPOS-00049
-    - SV-253072r824888_rule
     - TOSS-04-040170
     - DISA-STIG-TOSS-04-040170
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040180.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040180.yml
@@ -15,7 +15,6 @@
   tags:
     - V-253073
     - SRG-OS-000095-GPOS-00049
-    - SV-253073r824891_rule
     - TOSS-04-040180
     - DISA-STIG-TOSS-04-040180
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040190.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040190.yml
@@ -34,7 +34,6 @@
   tags:
     - V-253074
     - SRG-OS-000095-GPOS-00049
-    - SV-253074r824894_rule
     - TOSS-04-040190
     - DISA-STIG-TOSS-04-040190
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040200.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040200.yml
@@ -25,7 +25,6 @@
   tags:
     - V-253075
     - SRG-OS-000095-GPOS-00049
-    - SV-253075r824897_rule
     - TOSS-04-040200
     - DISA-STIG-TOSS-04-040200
     - medium_severity
@@ -44,7 +43,6 @@
   tags:
     - V-253075
     - SRG-OS-000095-GPOS-00049
-    - SV-253075r824897_rule
     - TOSS-04-040200
     - DISA-STIG-TOSS-04-040200
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040210.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040210.yml
@@ -25,7 +25,6 @@
   tags:
     - V-253076
     - SRG-OS-000095-GPOS-00049
-    - SV-253076r824900_rule
     - TOSS-04-040210
     - DISA-STIG-TOSS-04-040210
     - medium_severity
@@ -44,7 +43,6 @@
   tags:
     - V-253076
     - SRG-OS-000095-GPOS-00049
-    - SV-253076r824900_rule
     - TOSS-04-040210
     - DISA-STIG-TOSS-04-040210
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040220.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040220.yml
@@ -25,7 +25,6 @@
   tags:
     - V-253077
     - SRG-OS-000095-GPOS-00049
-    - SV-253077r824903_rule
     - TOSS-04-040220
     - DISA-STIG-TOSS-04-040220
     - medium_severity
@@ -44,7 +43,6 @@
   tags:
     - V-253077
     - SRG-OS-000095-GPOS-00049
-    - SV-253077r824903_rule
     - TOSS-04-040220
     - DISA-STIG-TOSS-04-040220
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040230.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040230.yml
@@ -14,7 +14,6 @@
   tags:
     - V-253078
     - SRG-OS-000095-GPOS-00049
-    - SV-253078r824906_rule
     - TOSS-04-040230
     - DISA-STIG-TOSS-04-040230
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040250.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040250.yml
@@ -14,7 +14,6 @@
   tags:
     - V-253079
     - SRG-OS-000095-GPOS-00049
-    - SV-253079r824909_rule
     - TOSS-04-040250
     - DISA-STIG-TOSS-04-040250
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040260.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040260.yml
@@ -14,7 +14,6 @@
   tags:
     - V-253080
     - SRG-OS-000095-GPOS-00049
-    - SV-253080r824912_rule
     - TOSS-04-040260
     - DISA-STIG-TOSS-04-040260
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040270.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040270.yml
@@ -32,7 +32,6 @@
   tags:
     - V-253081
     - SRG-OS-000096-GPOS-00050
-    - SV-253081r824915_rule
     - TOSS-04-040270
     - DISA-STIG-TOSS-04-040270
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040280.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040280.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253082
     - SRG-OS-000114-GPOS-00059
-    - SV-253082r824918_rule
     - TOSS-04-040280
     - DISA-STIG-TOSS-04-040280
     - medium_severity
@@ -46,7 +45,6 @@
   tags:
     - V-253082
     - SRG-OS-000114-GPOS-00059
-    - SV-253082r824918_rule
     - TOSS-04-040280
     - DISA-STIG-TOSS-04-040280
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040290.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040290.yml
@@ -37,7 +37,6 @@
   tags:
     - V-253083
     - SRG-OS-000126-GPOS-00066
-    - SV-253083r824921_rule
     - TOSS-04-040290
     - DISA-STIG-TOSS-04-040290
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040310.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040310.yml
@@ -15,7 +15,6 @@
   tags:
     - V-253084
     - SRG-OS-000134-GPOS-00068
-    - SV-253084r824924_rule
     - TOSS-04-040310
     - DISA-STIG-TOSS-04-040310
     - low_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040330.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040330.yml
@@ -29,7 +29,6 @@
   tags:
     - V-253085
     - SRG-OS-000185-GPOS-00079
-    - SV-253085r824927_rule
     - TOSS-04-040330
     - DISA-STIG-TOSS-04-040330
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040340.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040340.yml
@@ -41,7 +41,6 @@
   tags:
     - V-253086
     - SRG-OS-000259-GPOS-00100
-    - SV-253086r824930_rule
     - TOSS-04-040340
     - DISA-STIG-TOSS-04-040340
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040350.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040350.yml
@@ -17,7 +17,6 @@
   tags:
     - V-253087
     - SRG-OS-000266-GPOS-00101
-    - SV-253087r824933_rule
     - TOSS-04-040350
     - DISA-STIG-TOSS-04-040350
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040370.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040370.yml
@@ -24,7 +24,6 @@
   tags:
     - V-253088
     - SRG-OS-000297-GPOS-00115
-    - SV-253088r824936_rule
     - TOSS-04-040370
     - DISA-STIG-TOSS-04-040370
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040390.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040390.yml
@@ -41,7 +41,6 @@
   tags:
     - V-253089
     - SRG-OS-000342-GPOS-00133
-    - SV-253089r824939_rule
     - TOSS-04-040390
     - DISA-STIG-TOSS-04-040390
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040420.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040420.yml
@@ -25,7 +25,6 @@
   tags:
     - V-253090
     - SRG-OS-000376-GPOS-00161
-    - SV-253090r824942_rule
     - TOSS-04-040420
     - DISA-STIG-TOSS-04-040420
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040440.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040440.yml
@@ -36,7 +36,6 @@
   tags:
     - V-253091
     - SRG-OS-000393-GPOS-00173
-    - SV-253091r824945_rule
     - TOSS-04-040440
     - DISA-STIG-TOSS-04-040440
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040480.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040480.yml
@@ -17,7 +17,6 @@
   tags:
     - V-253092
     - SRG-OS-000420-GPOS-00186
-    - SV-253092r824948_rule
     - TOSS-04-040480
     - DISA-STIG-TOSS-04-040480
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040490.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040490.yml
@@ -35,7 +35,6 @@
   tags:
     - V-253093
     - SRG-OS-000433-GPOS-00192
-    - SV-253093r824951_rule
     - TOSS-04-040490
     - DISA-STIG-TOSS-04-040490
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040500.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040500.yml
@@ -17,7 +17,6 @@
   tags:
     - V-253094
     - SRG-OS-000437-GPOS-00194
-    - SV-253094r824954_rule
     - TOSS-04-040500
     - DISA-STIG-TOSS-04-040500
     - low_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040510.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040510.yml
@@ -28,6 +28,5 @@
     - hpc_issue
     - medium_severity
     - SRG-OS-000445-GPOS-00199
-    - SV-253095r824957_rule
     - TOSS-04-040510
     - V-253095

--- a/ansible/roles/stig/tasks/TOSS_04_040540.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040540.yml
@@ -23,7 +23,7 @@
   tags:
     - V-253096
     - SRG-OS-000480-GPOS-00225
-    - SV-253096r824960_rule
+    - DISA-STIG-TOSS-04-040540
     - TOSS-04-040540
     - medium_severity
     - CCI-000366

--- a/ansible/roles/stig/tasks/TOSS_04_040540.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040540.yml
@@ -21,6 +21,5 @@
     - SRG-OS-000480-GPOS-00225
     - SV-253096r824960_rule
     - TOSS-04-040540
-    - DISA-STIG-TOSS-04-040540
     - medium_severity
     - CCI-000366

--- a/ansible/roles/stig/tasks/TOSS_04_040550.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040550.yml
@@ -16,7 +16,6 @@
   tags:
     - V-253097
     - SRG-OS-000480-GPOS-00226
-    - SV-253097r824963_rule
     - TOSS-04-040550
     - DISA-STIG-TOSS-04-040550
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040560.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040560.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253098
     - SRG-OS-000480-GPOS-00227
-    - SV-253098r824966_rule
     - TOSS-04-040560
     - DISA-STIG-TOSS-04-040560
     - high_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040570.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040570.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253099
     - SRG-OS-000480-GPOS-00227
-    - SV-253099r824969_rule
     - TOSS-04-040570
     - DISA-STIG-TOSS-04-040570
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040580.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040580.yml
@@ -26,7 +26,6 @@
   tags:
     - V-253100
     - SRG-OS-000480-GPOS-00227
-    - SV-253100r824972_rule
     - TOSS-04-040580
     - DISA-STIG-TOSS-04-040580
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040590.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040590.yml
@@ -39,7 +39,6 @@
   tags:
     - V-253101
     - SRG-OS-000480-GPOS-00227
-    - SV-253101r824975_rule
     - TOSS-04-040590
     - DISA-STIG-TOSS-04-040590
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040600.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040600.yml
@@ -55,7 +55,6 @@
   tags:
     - V-253102
     - SRG-OS-000480-GPOS-00227
-    - SV-253102r824978_rule
     - TOSS-04-040600
     - DISA-STIG-TOSS-04-040600
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040610.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040610.yml
@@ -19,7 +19,6 @@
   tags:
     - V-253103
     - SRG-OS-000480-GPOS-00227
-    - SV-253103r824981_rule
     - TOSS-04-040610
     - DISA-STIG-TOSS-04-040610
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040630.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040630.yml
@@ -39,6 +39,5 @@
     - DISA-STIG-TOSS-04-040630
     - low_severity
     - SRG-OS-000480-GPOS-00227
-    - SV-253104r824984_rule
     - TOSS-04-040630
     - V-253104

--- a/ansible/roles/stig/tasks/TOSS_04_040640.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040640.yml
@@ -38,7 +38,6 @@
   tags:
     - V-253105
     - SRG-OS-000480-GPOS-00227
-    - SV-253105r824987_rule
     - TOSS-04-040640
     - DISA-STIG-TOSS-04-040640
     - low_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040650.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040650.yml
@@ -21,7 +21,6 @@
   tags:
     - V-253106
     - SRG-OS-000480-GPOS-00227
-    - SV-253106r824990_rule
     - TOSS-04-040650
     - DISA-STIG-TOSS-04-040650
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040660.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040660.yml
@@ -30,6 +30,5 @@
     - DISA-STIG-TOSS-04-040660
     - medium_severity
     - SRG-OS-000480-GPOS-00227
-    - SV-253107r824993_rule
     - TOSS-04-040660
     - V-253107

--- a/ansible/roles/stig/tasks/TOSS_04_040670.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040670.yml
@@ -31,6 +31,5 @@
     - DISA-STIG-TOSS-04-040670
     - medium_severity
     - SRG-OS-000480-GPOS-00227
-    - SV-253108r824996_rule
     - TOSS-04-040670
     - V-253108

--- a/ansible/roles/stig/tasks/TOSS_04_040680.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040680.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253109
     - SRG-OS-000480-GPOS-00227
-    - SV-253109r824999_rule
     - TOSS-04-040680
     - DISA-STIG-TOSS-04-040680
     - high_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040690.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040690.yml
@@ -36,7 +36,6 @@
   tags:
     - V-253110
     - SRG-OS-000480-GPOS-00227
-    - SV-253110r825002_rule
     - TOSS-04-040690
     - DISA-STIG-TOSS-04-040690
     - high_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040700.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040700.yml
@@ -43,7 +43,6 @@
   tags:
     - V-253111
     - SRG-OS-000480-GPOS-00227
-    - SV-253111r825005_rule
     - TOSS-04-040700
     - DISA-STIG-TOSS-04-040700
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040710.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040710.yml
@@ -21,7 +21,6 @@
   tags:
     - V-253112
     - SRG-OS-000480-GPOS-00227
-    - SV-253112r825008_rule
     - TOSS-04-040710
     - DISA-STIG-TOSS-04-040710
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040720.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040720.yml
@@ -18,7 +18,6 @@
   tags:
     - V-253113
     - SRG-OS-000480-GPOS-00227
-    - SV-253113r825011_rule
     - TOSS-04-040720
     - DISA-STIG-TOSS-04-040720
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040730.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040730.yml
@@ -17,7 +17,6 @@
   tags:
     - V-253114
     - SRG-OS-000480-GPOS-00227
-    - SV-253114r825014_rule
     - TOSS-04-040730
     - DISA-STIG-TOSS-04-040730
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040740.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040740.yml
@@ -17,7 +17,6 @@
   tags:
     - V-253115
     - SRG-OS-000480-GPOS-00227
-    - SV-253115r825017_rule
     - TOSS-04-040740
     - DISA-STIG-TOSS-04-040740
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040750.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040750.yml
@@ -16,7 +16,6 @@
   tags:
     - V-253116
     - SRG-OS-000480-GPOS-00227
-    - SV-253116r825020_rule
     - TOSS-04-040750
     - DISA-STIG-TOSS-04-040750
     - low_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040760.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040760.yml
@@ -15,7 +15,6 @@
   tags:
     - V-253117
     - SRG-OS-000480-GPOS-00227
-    - SV-253117r825023_rule
     - TOSS-04-040760
     - DISA-STIG-TOSS-04-040760
     - low_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040770.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040770.yml
@@ -21,7 +21,6 @@
   tags:
     - V-253118
     - SRG-OS-000480-GPOS-00227
-    - SV-253118r825026_rule
     - TOSS-04-040770
     - DISA-STIG-TOSS-04-040770
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040780.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040780.yml
@@ -21,7 +21,6 @@
   tags:
     - V-253119
     - SRG-OS-000480-GPOS-00227
-    - SV-253119r825029_rule
     - TOSS-04-040780
     - DISA-STIG-TOSS-04-040780
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040790.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040790.yml
@@ -22,7 +22,6 @@
   tags:
     - V-253120
     - SRG-OS-000480-GPOS-00227
-    - SV-253120r825032_rule
     - TOSS-04-040790
     - DISA-STIG-TOSS-04-040790
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040800.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040800.yml
@@ -22,7 +22,6 @@
   tags:
     - V-253121
     - SRG-OS-000480-GPOS-00227
-    - SV-253121r825035_rule
     - TOSS-04-040800
     - DISA-STIG-TOSS-04-040800
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040810.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040810.yml
@@ -19,7 +19,6 @@
   tags:
     - V-253122
     - SRG-OS-000480-GPOS-00227
-    - SV-253122r825038_rule
     - TOSS-04-040810
     - DISA-STIG-TOSS-04-040810
     - high_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040820.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040820.yml
@@ -22,7 +22,6 @@
   tags:
     - V-253123
     - SRG-OS-000480-GPOS-00227
-    - SV-253123r825041_rule
     - TOSS-04-040820
     - DISA-STIG-TOSS-04-040820
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040830.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040830.yml
@@ -22,7 +22,6 @@
   tags:
     - V-253124
     - SRG-OS-000480-GPOS-00227
-    - SV-253124r825044_rule
     - TOSS-04-040830
     - DISA-STIG-TOSS-04-040830
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040840.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040840.yml
@@ -21,7 +21,6 @@
   tags:
     - V-253125
     - SRG-OS-000480-GPOS-00227
-    - SV-253125r825047_rule
     - TOSS-04-040840
     - DISA-STIG-TOSS-04-040840
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040850.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040850.yml
@@ -22,7 +22,6 @@
   tags:
     - V-253126
     - SRG-OS-000480-GPOS-00227
-    - SV-253126r825050_rule
     - TOSS-04-040850
     - DISA-STIG-TOSS-04-040850
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040860.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040860.yml
@@ -21,7 +21,6 @@
   tags:
     - V-253127
     - SRG-OS-000480-GPOS-00227
-    - SV-253127r825053_rule
     - TOSS-04-040860
     - DISA-STIG-TOSS-04-040860
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040870.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040870.yml
@@ -22,7 +22,6 @@
   tags:
     - V-253128
     - SRG-OS-000480-GPOS-00227
-    - SV-253128r825056_rule
     - TOSS-04-040870
     - DISA-STIG-TOSS-04-040870
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040880.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040880.yml
@@ -21,7 +21,6 @@
   tags:
     - V-253129
     - SRG-OS-000480-GPOS-00227
-    - SV-253129r825059_rule
     - TOSS-04-040880
     - DISA-STIG-TOSS-04-040880
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040890.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040890.yml
@@ -22,7 +22,6 @@
   tags:
     - V-253130
     - SRG-OS-000480-GPOS-00227
-    - SV-253130r825062_rule
     - TOSS-04-040890
     - DISA-STIG-TOSS-04-040890
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040900.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040900.yml
@@ -22,7 +22,6 @@
   tags:
     - V-253131
     - SRG-OS-000480-GPOS-00227
-    - SV-253131r825065_rule
     - TOSS-04-040900
     - DISA-STIG-TOSS-04-040900
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040910.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040910.yml
@@ -17,7 +17,6 @@
   tags:
     - V-253132
     - SRG-OS-000480-GPOS-00227
-    - SV-253132r825068_rule
     - TOSS-04-040910
     - DISA-STIG-TOSS-04-040910
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040920.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040920.yml
@@ -30,7 +30,6 @@
   tags:
     - V-253133
     - SRG-OS-000480-GPOS-00227
-    - SV-253133r826066_rule
     - TOSS-04-040920
     - DISA-STIG-TOSS-04-040920
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040930.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040930.yml
@@ -33,7 +33,6 @@
   tags:
     - V-253134
     - SRG-OS-000480-GPOS-00227
-    - SV-253134r825074_rule
     - TOSS-04-040930
     - DISA-STIG-TOSS-04-040930
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040940.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040940.yml
@@ -33,7 +33,6 @@
   tags:
     - V-253135
     - SRG-OS-000480-GPOS-00227
-    - SV-253135r825077_rule
     - TOSS-04-040940
     - DISA-STIG-TOSS-04-040940
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040950.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040950.yml
@@ -36,7 +36,6 @@
   tags:
     - V-253136
     - SRG-OS-000312-GPOS-00122
-    - SV-253136r825080_rule
     - TOSS-04-040950
     - DISA-STIG-TOSS-04-040950
     - medium_severity

--- a/ansible/roles/stig/tasks/TOSS_04_040960.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_040960.yml
@@ -37,7 +37,6 @@
   tags:
     - V-253137
     - SRG-OS-000312-GPOS-00122
-    - SV-253137r825083_rule
     - TOSS-04-040960
     - DISA-STIG-TOSS-04-040960
     - medium_severity

--- a/parser/task_template.yml.j2
+++ b/parser/task_template.yml.j2
@@ -1,6 +1,6 @@
 # https://www.stigviewer.com/stig/toss_4/2023-xx-xx/finding/{{vuln_id}}
 
-{% for line in check_text.splitlines() -%} 
+{% for line in check_text.splitlines() -%}
 # {{line}}
 {%endfor%}
 
@@ -11,7 +11,6 @@
   tags:
     - {{ vuln_id }}  {# V-252911 #}
     - {{ group_title }}  {# SRG-OS-000023-GPOS-00006 #}
-    - {{ rule_id }}  {# SV-252911r824057_rule #}
     - {{ stig_id }}  {# TOSS-04-010000 #}
     - {{ "DISA-STIG-" + stig_id}}  {# DISA-STIG-TOSS-04-010000 #}
     - {{ severity + "_severity" }}  {# medium_severity #}

--- a/stig.py
+++ b/stig.py
@@ -215,7 +215,6 @@ def toss_04_010000(expected_banner: str = None):
     or remote access to the system.
 
     Vul ID: V-252911
-    Rule ID: SV-252911r824057_rule
     STIG ID: TOSS-04-010000
     Severity: CAT II
     Classification: Unclass
@@ -243,7 +242,6 @@ def toss_04_010010(ca_path: str = "/etc/sssd/pki/sssd_auth_ca_db.pem"):
     trust anchor.
 
     Vul ID: V-252912
-    Rule ID: SV-252912r824060_rule
     STIG ID: TOSS-04-010010
     Severity: CAT II Classification: Unclass
 
@@ -264,7 +262,6 @@ def toss_04_010020(fake_password: str = None):
     Rule Title: TOSS, for PKI-based authentication, must enforce authorized access to the corresponding private key.
 
     Vul ID: V-252913
-    Rule ID: SV-252913r824063_rule
     STIG ID: TOSS-04-010020
     Severity: CAT II
     Classification: Unclass


### PR DESCRIPTION
@cdefrates identified TOSS 4 STIG items do not have the same rule ID for its entire existence, possibly changing when updates are made to the control. This pull request is removing the rule ID tags for all TOSS 4 STIG items.