### PR TITLE
corrections in TOSS STIG items ending in 030000 through 030090

### DIFF
--- a/ansible/roles/stig/defaults/main.yml
+++ b/ansible/roles/stig/defaults/main.yml
@@ -6,6 +6,7 @@ auditd_max_log_file_action: 'rotate'
 auditd_flush: 'incremental_async'
 auditd_space_left: '100'
 auditd_space_left_action: 'email'
+audit_log_file: '/var/log/audit/audit.log'
 
 login_banner_text: You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.\n\nBy using this IS (which includes any device attached to this IS), you consent to the following conditions:\n\n-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.\n\n-At any time, the USG may inspect and seize data stored on this IS.\n\n-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.\n\n-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.\n\n-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details.
 

--- a/ansible/roles/stig/tasks/TOSS_04_030000.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030000.yml
@@ -17,7 +17,7 @@
 
 - name: TOSS-04-030000 - TOSS must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/shadow.
   ansible.builtin.lineinfile:
-    path: /etc/audit/rules.d/audit.rules
+    path: /etc/audit/audit.rules
     line: -w /etc/shadow -p wa -k identity
   notify: Build auditd rules
   when:

--- a/ansible/roles/stig/tasks/TOSS_04_030060.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030060.yml
@@ -13,7 +13,7 @@
 
 - name: TOSS-04-030060 - TOSS must generate audit records containing the full-text recording of privileged commands.
   ansible.builtin.lineinfile:
-    path: /etc/audit/rules.d/audit.rules
+    path: /etc/audit/audit.rules
     line: -a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -k priv_cmd
   notify: Build auditd rules
   when:

--- a/ansible/roles/stig/tasks/TOSS_04_030080.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030080.yml
@@ -1,16 +1,5 @@
 # https://www.stigviewer.com/stig/tri-lab_operating_system_stack_toss_4/2022-08-29/finding/V-252975
 
-# Verify that the SA and ISSO (at a minimum) are notified in the event
-# of an audit processing failure. Check that TOSS notifies the SA and ISSO (at a
-# minimum) in the event of an audit processing failure with the following command:
-# $ sudo grep action_mail_acct /etc/audit/auditd.conf action_mail_acct = root If
-# the value of the "action_mail_acct" keyword is not set to "root" and/or other
-# accounts for security personnel, the "action_mail_acct" keyword is missing, or
-# the retuned line is commented out, ask the system administrator to indicate how
-# they and the ISSO are notified of an audit process failure. If there is no
-# evidence of the proper personnel being notified of an audit processing failure,
-# this is a finding.
-
 # Verify that the SA and ISSO (at a minimum) are notified in the event of
 # an audit processing failure.
 #

--- a/ansible/roles/stig/tasks/TOSS_04_030090.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030090.yml
@@ -16,9 +16,19 @@
 
 
 - name: TOSS-04-030090 - TOSS must take appropriate action when an audit processing failure occurs.
-  ansible.builtin.lineinfile:
-    path: /etc/audit/auditd.conf
-    line: disk_error_action = HALT
+  block:
+    - name: get value
+      ansible.builtin.lineinfile:
+        path: /etc/audit/auditd.conf
+        line: disk_error_action = HALT
+        validate: 'grep disk_error_action %s'
+      register: disk_error_action
+    - name: verify value
+      ansible.builtin.lineinfile:
+        path: /etc/audit/auditd.conf
+        line: disk_error_action = HALT
+      when:
+        - (disk_error_action.msg is not search('.*SYSLOG.*')) or (disk_error_action.msg is not search('.*SINGLE.*')) or (disk_error_action.msg is not search('.*HALT.*'))
   when:
     - toss_04_030090 | bool
   tags:

--- a/ansible/roles/stig/tasks/TOSS_04_030090.yml
+++ b/ansible/roles/stig/tasks/TOSS_04_030090.yml
@@ -17,13 +17,13 @@
 
 - name: TOSS-04-030090 - TOSS must take appropriate action when an audit processing failure occurs.
   block:
-    - name: get value
+    - name: TOSS-04-030090 - see setting for disk_error_action
       ansible.builtin.lineinfile:
         path: /etc/audit/auditd.conf
         line: disk_error_action = HALT
         validate: 'grep disk_error_action %s'
       register: disk_error_action
-    - name: verify value
+    - name: TOSS-04-030090 - verify setting for disk_error_action is an approved value
       ansible.builtin.lineinfile:
         path: /etc/audit/auditd.conf
         line: disk_error_action = HALT


### PR DESCRIPTION
Made corrections for TOSS STIG items ending in 030000 through 030090 as needed. Some did not do all the asks in the checktext, while others may prevent the ansible playbook from completing or may break a system or cluster.